### PR TITLE
Add core.async support for field resolver functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## 0.2.0 -- UNRELEASED
 
-Updated to Lacinia 0.16.0.
+The library and GitHub project have been renamed from `pedestal-lacinia` to
+`lacinia-pedestal`.
+
+Updated to Lacinia 0.17.0.
 
 Added an option to execute the GraphQL request asynchronously; when enabled,
 the handler returns a channel that conveys the Pedestal context containing
@@ -8,6 +11,9 @@ the response, once the query has finished executing.
 
 Introduced function `com.walmartlabs.lacinia.pedestal/inject-app-context-interceptor` and
 converted `query-executor-handler` from a function to constant.
+
+A new namespace, `com.walmartlabs.lacinia.async`, includes functions to adapt
+field resolvers that return clojure.core.async channels to Lacinia.
 
 ## 0.1.1 -- 19 Apr 2017
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# com.walmartlabs/pedestal-lacinia
+# com.walmartlabs/lacinia-pedestal
 
-[![Clojars Project](https://img.shields.io/clojars/v/com.walmartlabs/pedestal-lacinia.svg)](https://clojars.org/com.walmartlabs/pedestal-lacinia)
+[![Clojars Project](https://img.shields.io/clojars/v/com.walmartlabs/lacinia-pedestal.svg)](https://clojars.org/com.walmartlabs/lacinia-pedestal)
 
 A library that adds the
 [Pedestal](https://github.com/pedestal/pedestal) underpinnings needed when exposing
 [Lacinia](https://github.com/walmartlabs/lacinia) as an HTTP endpoint.
 
-[API Documentation](http://walmartlabs.github.io/pedestal-lacinia/)
+[API Documentation](http://walmartlabs.github.io/lacinia-pedestal/)
 
 ## Usage
 

--- a/project.clj
+++ b/project.clj
@@ -1,19 +1,19 @@
-(defproject com.walmartlabs/pedestal-lacinia "0.2.0"
+(defproject com.walmartlabs/lacinia-pedestal "0.2.0"
   :description "Pedestal infrastructure supporting Lacinia GraphQL"
   :url "https://github.com/walmartlabs/pedestal-lacinia"
   :license {:name "Apache Software License 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [com.walmartlabs/lacinia "0.16.0"]
-                 [com.fasterxml.jackson.core/jackson-core "2.5.3"]
+                 [com.walmartlabs/lacinia "0.17.0"]
+                 [com.fasterxml.jackson.core/jackson-core "2.8.8"]
                  [io.pedestal/pedestal.service "0.5.2"]
                  [io.pedestal/pedestal.jetty "0.5.2"]]
   :profiles
   {:dev {:dependencies [[clj-http "2.0.0"]
                         [io.aviso/logging "0.2.0"]]}}
   :jvm-opts ["-Xmx500m"]
-  :plugins [[lein-codox "0.10.2"]
-            [test2junit "1.2.5"]
+  :plugins [[lein-codox "0.10.3"]
+            [test2junit "1.3.0"]
             [lein-shell "0.5.0"]]
   :shell {:dir "resources/graphiql"}
   :prep-tasks [["shell" "./build"]]

--- a/src/com/walmartlabs/lacinia/async.clj
+++ b/src/com/walmartlabs/lacinia/async.clj
@@ -1,0 +1,33 @@
+(ns com.walmartlabs.lacinia.async
+  "Facilities for leveraging core.async with Lacinia."
+  {:added "0.2.0"}
+  (:require
+    [clojure.core.async :refer [take!]]
+    [com.walmartlabs.lacinia.resolve :as resolve]
+    [com.walmartlabs.lacinia.util :refer [as-error-map]]))
+
+(defn channel->result
+  "Converts a core.async channel into a Lacinia ResolverResult.
+
+  If the channel conveys an exception, that is converted to an error map and delivered (with a nil value).
+
+  Otherwise the first value conveyed is delivered."
+  [ch]
+  (let [result (resolve/resolve-promise)]
+    (take! ch (fn [value]
+                (if (instance? Throwable value)
+                  (resolve/deliver! result nil (as-error-map value))
+                  (resolve/deliver! result value))))
+    result))
+
+(defn decorate-channel->result
+  "A field resolver decorator that ensures that a field resolver that returns a channel will be wrapped
+  to return a ResolverResult.
+
+  Only functions that have the meta-data :channel-result are wrapped."
+  [object-name field-name f]
+  (if (-> f meta :channel-result)
+    ^resolve/ResolverResult
+    (fn [context args value]
+      (channel->result (f context args value)))
+    f))

--- a/src/com/walmartlabs/lacinia/pedestal.clj
+++ b/src/com/walmartlabs/lacinia/pedestal.clj
@@ -86,7 +86,8 @@
                 (assoc context :request
                        (merge request q))))}))
 
-(defn query-not-found-error [request]
+(defn ^:private query-not-found-error
+  [request]
   (let [request-method (get request :request-method)
         content-type (get-in request [:headers "content-type"])
         body (get request :body)]

--- a/src/com/walmartlabs/lacinia/pedestal.clj
+++ b/src/com/walmartlabs/lacinia/pedestal.clj
@@ -289,8 +289,7 @@
   [compiled-schema options]
   (->
     {:env (:env options :dev)
-     ::http/routes (-> (graphql-routes compiled-schema options)
-                       route/expand-routes)
+     ::http/routes (route/expand-routes (graphql-routes compiled-schema options))
      ::http/port (:port options 8888)
      ::http/type :jetty
      ::http/join? false}

--- a/src/com/walmartlabs/lacinia/pedestal.clj
+++ b/src/com/walmartlabs/lacinia/pedestal.clj
@@ -70,7 +70,7 @@
                   context)))}))
 
 (def body-data-interceptor
-  "Converts the POSTed body from a string into a string."
+  "Converts the POSTed body from a input stream into a string."
   (interceptor
    {:name ::body-data
     :enter (fn [context]

--- a/src/com/walmartlabs/lacinia/pedestal.clj
+++ b/src/com/walmartlabs/lacinia/pedestal.clj
@@ -274,6 +274,8 @@
   "Creates and returns a Pedestal service map, ready to be started.
   This uses a server type of :jetty.
 
+  The options are used here, and also passed to [[graphql-routes]].
+
   Options:
 
   :graphql (default: false)

--- a/test/com/walmartlabs/lacinia/async_test.clj
+++ b/test/com/walmartlabs/lacinia/async_test.clj
@@ -1,8 +1,11 @@
 (ns com.walmartlabs.lacinia.async-test
   (:require
     [clojure.test :refer [deftest is use-fixtures]]
+    [clojure.core.async :refer [go]]
+    [com.walmartlabs.lacinia.async :as async]
     [com.walmartlabs.lacinia.test-utils :refer [sample-schema-fixture
-                                                send-request]]))
+                                                send-request]]
+    [com.walmartlabs.lacinia.resolve :as resolve]))
 
 ;; TODO: Some way to verify that processing is actually async.
 
@@ -23,3 +26,32 @@
     (is (= {:data {:echo {:method "post"
                           :value "hello"}}}
            (:body response)))))
+
+
+(defn ^:private make-chan-resolver
+  [value]
+  ^:channel-result
+  (fn [_ _ _] (go value)))
+
+(defn ^:private execute-resolver
+  [conveyed-value]
+  (let [f (async/decorate-channel->result nil nil (make-chan-resolver conveyed-value))
+        *p (promise)]
+    (resolve/on-deliver! (f nil nil nil)
+                         (fn [value error]
+                           (deliver *p [value error])))
+    @*p))
+
+(deftest decorate-non-channel-result-is-no-op
+  (let [f (fn [_ _ _])]
+    (is (identical? f
+                    (async/decorate-channel->result nil nil f)))))
+
+(deftest decorate-chan-normal-case
+  (is (= [::value nil]
+         (execute-resolver ::value))))
+
+(deftest decoreate-chan-exception-case
+  (is (= [nil {:message "Resolver exception."
+               :status 500}]
+         (execute-resolver (ex-info "Resolver exception." {:status 500})))))


### PR DESCRIPTION
This adds a field resolver decorator whose purpose is to wrap functions that return a core.async channel so that they return a ResolverResult.

I also fixed up some documentation, and renamed the library to lacinia-pedestal.