### PR TITLE
Corrects docs for `pedestal-service` & graphiql

### DIFF
--- a/src/com/walmartlabs/lacinia/pedestal.clj
+++ b/src/com/walmartlabs/lacinia/pedestal.clj
@@ -266,7 +266,7 @@
 
   Options:
 
-  :graphql (default: false)
+  :graphiql (default: false)
   : If given, then enables resources to support the GraphiQL IDE
 
   :port (default: 8888)


### PR DESCRIPTION
Fixes documentation mentioned in issue #7.