### PR TITLE
Correct namespace in README.md and add example usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A library that adds the
 ## Usage
 
 For a basic Pedestal server, simply supply a compiled Lacinia schema to
-the `com.walmart.lacinia.pedestal/pedestal-service` function to
+the `com.walmartlabs.lacinia.pedestal/pedestal-service` function to
 generate a service, then invoke `io.pedestal.http/start`.
 
 Lacinia will handle GET and POST requests at the `/graphql` endpoint.

--- a/README.md
+++ b/README.md
@@ -15,13 +15,17 @@ the `com.walmartlabs.lacinia.pedestal/pedestal-service` function to
 generate a service, then invoke `io.pedestal.http/start`.
 
 ```clojure
-(ns graphql-demo.service
-  (:gen-class)
+(ns graphql-demo.server
+  (:gen-class) ; for -main method in uberjar
   (:require [io.pedestal.http :as server]
             [com.walmartlabs.lacinia.pedestal :as lacinia]
-            [graphql-demo.schema :as schema]))
+            [com.walmartlabs.lacinia.schema :as schema]))
 
-(def service (lacinia/pedestal-service schema/my-compiled-schema {:graphiql true}))
+(def hello-schema (schema/compile
+                   {:queries {:hello 
+                              {:type 'String :resolve (constantly "world")}}}))
+
+(def service (lacinia/pedestal-service hello-schema {:graphiql true}))
 
 ;; This is an adapted service map, that can be started and stopped
 ;; From the REPL you can call server/start and server/stop on this service
@@ -38,7 +42,6 @@ generate a service, then invoke `io.pedestal.http/start`.
   [& args]
   (println "\nCreating your server...")
   (server/start runnable-service))
-
 ```
 
 Lacinia will handle GET and POST requests at the `/graphql` endpoint.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ the `com.walmartlabs.lacinia.pedestal/pedestal-service` function to
 generate a service, then invoke `io.pedestal.http/start`.
 
 ```clojure
+;; This example is based off of the code generated from the template
+;;  `lein new pedestal-service graphql-demo`
+
 (ns graphql-demo.server
   (:gen-class) ; for -main method in uberjar
   (:require [io.pedestal.http :as server]
@@ -47,6 +50,8 @@ generate a service, then invoke `io.pedestal.http/start`.
 ```
 
 Lacinia will handle GET and POST requests at the `/graphql` endpoint.
+
+`curl localhost:8888/graphql -X POST -H "content-type: application/graphql" -d '{ hello }'`
 
 When the `:graphiql` option is true, then a
 [GraphiQL](https://github.com/graphql/graphiql) IDE will be available at `/`.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,33 @@ For a basic Pedestal server, simply supply a compiled Lacinia schema to
 the `com.walmartlabs.lacinia.pedestal/pedestal-service` function to
 generate a service, then invoke `io.pedestal.http/start`.
 
+```clojure
+(ns graphql-demo.service
+  (:gen-class)
+  (:require [io.pedestal.http :as server]
+            [com.walmartlabs.lacinia.pedestal :as lacinia]
+            [graphql-demo.schema :as schema]))
+
+(def service (lacinia/pedestal-service schema/my-compiled-schema {:graphiql true}))
+
+;; This is an adapted service map, that can be started and stopped
+;; From the REPL you can call server/start and server/stop on this service
+(defonce runnable-service (server/create-server service))
+
+(defn run-dev
+  "The entry-point for 'lein run-dev'"
+  [& args]
+  (println "\nCreating your [DEV] server...")
+  (server/start service))
+
+(defn -main
+  "The entry-point for 'lein run'"
+  [& args]
+  (println "\nCreating your server...")
+  (server/start runnable-service))
+
+```
+
 Lacinia will handle GET and POST requests at the `/graphql` endpoint.
 
 When the `:graphiql` option is true, then a

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ generate a service, then invoke `io.pedestal.http/start`.
 ;;  `lein new pedestal-service graphql-demo`
 
 (ns graphql-demo.server
-  (:gen-class) ; for -main method in uberjar
   (:require [io.pedestal.http :as server]
             [com.walmartlabs.lacinia.pedestal :as lacinia]
             [com.walmartlabs.lacinia.schema :as schema]))
@@ -36,12 +35,6 @@ generate a service, then invoke `io.pedestal.http/start`.
 ;; From the REPL you can call server/start and server/stop on this service
 (defonce runnable-service (server/create-server service))
 
-(defn run-dev
-  "The entry-point for 'lein run-dev'"
-  [& args]
-  (println "\nCreating your [DEV] server...")
-  (server/start service))
-
 (defn -main
   "The entry-point for 'lein run'"
   [& args]
@@ -51,7 +44,10 @@ generate a service, then invoke `io.pedestal.http/start`.
 
 Lacinia will handle GET and POST requests at the `/graphql` endpoint.
 
-`curl localhost:8888/graphql -X POST -H "content-type: application/graphql" -d '{ hello }'`
+```
+$ curl localhost:8888/graphql -X POST -H "content-type: application/graphql" -d '{ hello }'
+{"data":{"hello":"world"}}
+`
 
 When the `:graphiql` option is true, then a
 [GraphiQL](https://github.com/graphql/graphiql) IDE will be available at `/`.

--- a/README.md
+++ b/README.md
@@ -22,8 +22,10 @@ generate a service, then invoke `io.pedestal.http/start`.
             [com.walmartlabs.lacinia.schema :as schema]))
 
 (def hello-schema (schema/compile
-                   {:queries {:hello 
-                              {:type 'String :resolve (constantly "world")}}}))
+                   {:queries {:hello
+                              ;; String is quoted here; in EDN the quotation is not required
+                              {:type 'String 
+                               :resolve (constantly "world")}}}))
 
 (def service (lacinia/pedestal-service hello-schema {:graphiql true}))
 


### PR DESCRIPTION
This PR corrects the namespace in the README.md (#9) and adds a quick example server + curl to the usage section.