### PR TITLE
Minor simplifications to the subscriptions options

### DIFF
--- a/docs/subscriptions.rst
+++ b/docs/subscriptions.rst
@@ -56,10 +56,9 @@ The following keys are used:
   ``:keep-alive-ms``
     The interval at which keep-alive messages are sent to the client; defaults to 30 seconds.
 
-  ``:interceptors-configurator``
-    A function that is passed the map of interceptors for processing subscription requests, and
-    returns the same or update map.  This is to allow customization of the interceptor chain for
-    domain-specific logic.
+  ``:subscription-interceptors``
+    A seq of interceptors used when processing GraphQL query, mutation, or subscription requests
+    via the WebSocket connection. This is used when overriding the default interceptors.
 
 Endpoint
 --------

--- a/src/com/walmartlabs/lacinia/pedestal/interceptors.clj
+++ b/src/com/walmartlabs/lacinia/pedestal/interceptors.clj
@@ -10,7 +10,8 @@
 
   Dependencies are a seq of keywords.
 
-  with-dependencies is additive.
+  ordered-after is additive, invoking it multiple times will
+  accumulate dependencies.
 
   Returns the interceptor with updated metadata."
   [interceptor dependencies]

--- a/test/com/walmartlabs/lacinia/pedestal/subscription_interceptors_test.clj
+++ b/test/com/walmartlabs/lacinia/pedestal/subscription_interceptors_test.clj
@@ -1,0 +1,100 @@
+(ns com.walmartlabs.lacinia.pedestal.subscription-interceptors-test
+  (:require
+    [clojure.test :refer [deftest is use-fixtures]]
+    [clojure.core.async :refer [chan alt!! put! timeout]]
+    [com.walmartlabs.lacinia.test-utils
+     :refer [test-server-fixture *ping-subscribes *ping-cleanups]]
+    [io.pedestal.interceptor :refer [interceptor]]
+    [com.walmartlabs.lacinia.pedestal.subscriptions :as s]
+    [com.walmartlabs.lacinia.pedestal.interceptors :as i]
+    [cheshire.core :as cheshire]
+    [gniazdo.core :as g]
+    [io.pedestal.log :as log]
+    [clojure.string :as str]))
+
+(def ^:private uri "ws://localhost:8888/graphql-ws")
+
+(def ^:private *invoke-count (atom 0))
+
+(def ^:private invoke-count-interceptor
+  "Used to demonstrate that subscription interceptor customization works."
+  (interceptor
+    {:name ::invoke-count
+     :enter (fn [context]
+              (swap! *invoke-count inc)
+              context)}))
+
+(defn ^:private options-builder
+  [schema]
+  {:subscription-interceptors
+   ;; Add ::invoke-count, and ensure it executes before ::execute-operation.
+   (-> (s/default-interceptors schema nil)
+       (assoc ::invoke-count invoke-count-interceptor)
+       (update ::s/execute-operation i/ordered-after [::invoke-count])
+       i/order-by-dependency)})
+
+(use-fixtures :once (test-server-fixture {:subscriptions true
+                                          :keep-alive-ms 200}
+                                         options-builder))
+
+(def ^:private ^:dynamic *messages-ch* nil)
+
+(def ^:private ^:dynamic *session* nil)
+
+(defn send-data
+  [data]
+  (log/debug :reason ::send-data :data data)
+  (g/send-msg *session*
+              (cheshire/generate-string data)))
+
+(defn ^:private send-init
+  []
+  (send-data {:type :connection_init}))
+
+(defn ^:private <message!!
+  ([]
+   (<message!! 75))
+  ([timeout-ms]
+   (alt!!
+     *messages-ch* ([message] message)
+
+     (timeout timeout-ms) ::timed-out)))
+
+(defmacro ^:private expect-message
+  [expected]
+  `(is (= ~expected
+          (<message!!))))
+
+(use-fixtures :each
+  (fn [f]
+    (let [messages-ch (chan 10)
+          session (g/connect uri
+                             :on-receive (fn [message-text]
+                                           (log/debug :reason ::receive :message message-text)
+                                           (put! messages-ch (cheshire/parse-string message-text true))))]
+
+      (binding [*session* session
+                ;; New messages channel on each test as well, to ensure failed tests don't cause
+                ;; cascading failures.
+                *messages-ch* messages-ch]
+        (try
+          (reset! *invoke-count 0)
+          (f)
+          (finally
+            (g/close session)))))))
+
+(deftest added-interceptor-is-invoked
+  (send-init)
+  (expect-message {:type "connection_ack"})
+
+  (send-data {:id 987
+              :type :start
+              :payload
+              {:query "subscription { ping(message: \"short\", count: 2 ) { message }}"}})
+
+  (expect-message {:id 987
+                   :payload {:data {:ping {:message "short #1"}}}
+                   :type "data"})
+
+  (is (= 1 @*invoke-count)
+      "The added interceptor has been executed."))

--- a/test/com/walmartlabs/lacinia/pedestal/subscriptions_test.clj
+++ b/test/com/walmartlabs/lacinia/pedestal/subscriptions_test.clj
@@ -4,6 +4,9 @@
     [clojure.core.async :refer [chan alt!! put! timeout]]
     [com.walmartlabs.lacinia.test-utils
      :refer [test-server-fixture *ping-subscribes *ping-cleanups]]
+    [io.pedestal.interceptor :refer [interceptor]]
+    [com.walmartlabs.lacinia.pedestal.subscriptions :as s]
+    [com.walmartlabs.lacinia.pedestal.interceptors :as i]
     [cheshire.core :as cheshire]
     [gniazdo.core :as g]
     [io.pedestal.log :as log]
@@ -11,8 +14,29 @@
 
 (def ^:private uri "ws://localhost:8888/graphql-ws")
 
+(def ^:private *invoke-count (atom 0))
+
+(def ^:private invoke-count-interceptor
+  "Used to demonstrate that subscription interceptor customization works."
+  (interceptor
+    {:name ::invoke-count
+     :enter (fn [context]
+              (swap! *invoke-count inc)
+              context)}))
+
+(defn ^:private options-builder
+  [schema]
+  {:subscription-interceptors
+   ;; Add ::invoke-count, and ensure it executes before ::execute-operation.
+   (-> (s/default-interceptors schema nil)
+       (assoc ::invoke-count invoke-count-interceptor)
+       (update ::s/execute-operation i/ordered-after [::invoke-count])
+       i/order-by-dependency)})
+
+
 (use-fixtures :once (test-server-fixture {:subscriptions true
-                                          :keep-alive-ms 200}))
+                                          :keep-alive-ms 200}
+                                         options-builder))
 
 (def ^:private ^:dynamic *messages-ch* nil)
 
@@ -62,6 +86,7 @@
                 ;; cascading failures.
                 *messages-ch* messages-ch]
         (try
+          (reset! *invoke-count 0)
           (f)
           (finally
             (log/debug :reason ::test-end)
@@ -108,6 +133,9 @@
     (expect-message {:id id
                      :payload {:data {:ping {:message "short #1"}}}
                      :type "data"})
+
+    (is (= 1 @*invoke-count)
+        "The added interceptor has been executed.")
 
     (is (> @*ping-subscribes @*ping-cleanups)
         "A subscribe is active, but has not been cleaned up.")


### PR DESCRIPTION
Since the functions for creating the default interceptors are public, it is simpler to just allow passing a seq of interceptors, rather than a function that modifies the map of default interceptors.