### PR TITLE
Add Apollo compatible subscription support for GraphiQL [WIP]

### DIFF
--- a/resources/graphiql/index.html
+++ b/resources/graphiql/index.html
@@ -21,6 +21,8 @@
     <script src="//cdn.jsdelivr.net/fetch/0.9.0/fetch.min.js"></script>
     <script src="//cdn.jsdelivr.net/react/0.14.7/react.min.js"></script>
     <script src="//cdn.jsdelivr.net/react/0.14.7/react-dom.min.js"></script>
+    <script src=”//unpkg.com/subscriptions-transport-ws@0.5.4/browser/client.js”></script>
+    <script src="//unpkg.com/graphiql-subscriptions-fetcher@0.0.2/browser/client.js"></script>
     <script src="./graphiql.js"></script>
   </head>
   <body>
@@ -101,11 +103,13 @@
           }
         });
       }
+      var subscriptionsClient = new window.SubscriptionsTransportWs.SubscriptionClient(window.location.origin + '/graphql-ws', { reconnect: true });
+      var subscriptionsFetcher = window.SubscriptionsTransportWs.graphQLFetcher(subscriptionsClient, graphQLFetcher);
 
       // Render <GraphiQL /> into the body.
       ReactDOM.render(
         React.createElement(GraphiQL, {
-          fetcher: graphQLFetcher,
+          fetcher: subscriptionsFetcher,
           query: parameters.query,
           variables: parameters.variables,
           onEditQuery: onEditQuery,

--- a/resources/graphiql/index.html
+++ b/resources/graphiql/index.html
@@ -21,7 +21,7 @@
     <script src="//cdn.jsdelivr.net/fetch/0.9.0/fetch.min.js"></script>
     <script src="//cdn.jsdelivr.net/react/0.14.7/react.min.js"></script>
     <script src="//cdn.jsdelivr.net/react/0.14.7/react-dom.min.js"></script>
-    <script src=”//unpkg.com/subscriptions-transport-ws@0.5.4/browser/client.js”></script>
+    <script src="//unpkg.com/subscriptions-transport-ws@0.8.2/browser/client.js"></script>
     <script src="//unpkg.com/graphiql-subscriptions-fetcher@0.0.2/browser/client.js"></script>
     <script src="./graphiql.js"></script>
   </head>
@@ -103,8 +103,8 @@
           }
         });
       }
-      var subscriptionsClient = new window.SubscriptionsTransportWs.SubscriptionClient(window.location.origin + '/graphql-ws', { reconnect: true });
-      var subscriptionsFetcher = window.SubscriptionsTransportWs.graphQLFetcher(subscriptionsClient, graphQLFetcher);
+      var subscriptionsClient = new window.SubscriptionsTransportWs.SubscriptionClient(window.location.origin.replace('http', 'ws') + '/graphql-ws', { reconnect: true });
+      var subscriptionsFetcher = window.GraphiQLSubscriptionsFetcher.graphQLFetcher(subscriptionsClient, graphQLFetcher);
 
       // Render <GraphiQL /> into the body.
       ReactDOM.render(

--- a/src/com/walmartlabs/lacinia/pedestal/subscriptions.clj
+++ b/src/com/walmartlabs/lacinia/pedestal/subscriptions.clj
@@ -379,7 +379,8 @@
                          interceptors-configurator
                          interceptors/order-by-dependency)]
     (log/debug :event ::configuring :keep-alive-ms keep-alive-ms)
-    (fn [_ _ _]
+    (fn [req resp ws-map]
+      (.setAcceptedSubProtocol resp "graphql-ws")
       (log/debug :event ::upgrade-requested)
       (let [response-data-ch (chan 10)                      ; server data -> client
             ws-text-ch (chan 1)                             ; client text -> server

--- a/src/com/walmartlabs/lacinia/pedestal/subscriptions.clj
+++ b/src/com/walmartlabs/lacinia/pedestal/subscriptions.clj
@@ -98,7 +98,7 @@
         (async/timeout keep-alive-ms)
         (do
           (log/debug :event ::timeout)
-          (>! response-data-ch {:type :connection_keep_alive})
+          (>! response-data-ch {:type :ka})
           (recur subs))
 
         ws-data-ch


### PR DESCRIPTION
Apollo compatible clients are using websocket subprotocol `graphql-ws` and so the server must have support for that.

This PR adds `graphql-ws` as accepted subprotocol.

This PR also adds subscription support for GraphiQL IDE and changes keep-alive messages to `ka`-shorthand because it's the only allowed message type with Apollo client.

This PR is yet Work-In-Process and needs comments about separating it to three different pull requests (subprotocol, message types, graphiql-support?) and also how the subscription transport should be enabled (in frontend or with some templating in case of the subscription-support has been enabled from the backend)