### PR TITLE
Ensure that errors are in the regular format defined by the spec

### DIFF
--- a/dev-resources/com/walmartlabs/lacinia/test_utils.clj
+++ b/dev-resources/com/walmartlabs/lacinia/test_utils.clj
@@ -103,8 +103,9 @@
    (-> {:method method
         :url "http://localhost:8888/graphql"
         :throw-exceptions false
-        :body (cheshire/generate-string json)
         :headers {"Content-Type" content-type}}
+       (cond->
+         json (assoc :body (cheshire/generate-string json)))
        client/request
        (update :body
                #(try

--- a/docs/response.rst
+++ b/docs/response.rst
@@ -9,6 +9,18 @@ non-fatal errors.
 Fatal errors are those that occur before the query is executed;
 these represents parse failures or validation errors.
 
+Response Format
+---------------
+
+The response format is always ``application/json``.
+
+The response body is the result map from executing the query (e.g., has ``data`` and/or ``errors`` keys).
+
+In cases where there is a problem parsing or preparing the query, the response will still be in the
+regular format, e.g.::
+
+  {"errors": [{"message": "Request body is empty."}]}
+
 HTTP Status
 -----------
 

--- a/docs/subscriptions.rst
+++ b/docs/subscriptions.rst
@@ -75,7 +75,7 @@ the server sends WebSocket text messages for subscription updates and keep alive
 Subscription requests are not allowed in ``/graphql``.
 
 .. [#apollo] Apollo defines a `particular contract <https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md>`_
-  for how the client and server communicate; this includes heartbeats an explicit way for
-  the server to signal that the subscription has completed.
+  for how the client and server communicate; this includes heartbeats, and an explicit way for
+  the server to signal to the client that the subscription has completed.
 
-  The Apollo project also provides `clients in several languages <https://github.com/apollographql>_`.
+  The Apollo project also provides `clients in several languages <https://github.com/apollographql>`_.

--- a/project.clj
+++ b/project.clj
@@ -4,17 +4,17 @@
   :license {:name "Apache Software License 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [com.walmartlabs/lacinia "0.19.0"]
-                 [com.fasterxml.jackson.core/jackson-core "2.8.8"]
+                 [com.walmartlabs/lacinia "0.20.0"]
+                 [com.fasterxml.jackson.core/jackson-core "2.9.0"]
                  [io.pedestal/pedestal.service "0.5.2"]
                  [io.pedestal/pedestal.jetty "0.5.2"]
                  [com.stuartsierra/dependency "0.2.0"]]
   :profiles
-  {:dev {:dependencies [[clj-http "2.0.0"]
+  {:dev {:dependencies [[clj-http "2.3.0"]
 
                         ;; Overrides to match version of Jetty via Pedestal:
                         [org.eclipse.jetty.websocket/websocket-client "9.4.0.v20161208"]
-                        [stylefruits/gniazdo "1.0.0"
+                        [stylefruits/gniazdo "1.0.1"
                          :exclusions [org.eclipse.jetty.websocket/websocket-client]]
 
                         [io.aviso/logging "0.2.0"]]}}

--- a/src/com/walmartlabs/lacinia/pedestal.clj
+++ b/src/com/walmartlabs/lacinia/pedestal.clj
@@ -252,8 +252,8 @@
   (-> {:name ::disallow-subscriptions
        :enter (fn [context]
                 (if (-> context :request :parsed-lacinia-query parser/operations :type (= :subscription))
-                  (assoc context :response (bad-request (message-as-errors "Subscription queries must be processed by the WebSockets endpoint."))))
-                context)}
+                  (assoc context :response (bad-request (message-as-errors "Subscription queries must be processed by the WebSockets endpoint.")))
+                  context))}
       interceptor
       (ordered-after [::query-parser])))
 

--- a/src/com/walmartlabs/lacinia/pedestal.clj
+++ b/src/com/walmartlabs/lacinia/pedestal.clj
@@ -100,19 +100,16 @@
       interceptor
       (ordered-after [::json-response])))
 
-;; TODO: These are all inconsistent. Should probably all be in the form of
-;; {:errors [{:message "xxx"}]
-
 (defn ^:private query-not-found-error
   [request]
   (let [request-method (get request :request-method)
         content-type (get-in request [:headers "content-type"])
-        body (get request :body)]
-    (cond
-      (= request-method :get) "Query parameter 'query' is missing or blank."
-      (nil? body) "Request body is empty."
-      :else {:message "Request content type must be application/graphql or application/json."})))
-
+        body (get request :body)
+        message (cond
+                  (= request-method :get) "Query parameter 'query' is missing or blank."
+                  (str/blank? body) "Request body is empty."
+                  :else "Request content type must be application/graphql or application/json.")]
+    (message-as-errors message)))
 
 (def missing-query-interceptor
   "Rejects the request when there's no GraphQL query in the request map.
@@ -267,7 +264,7 @@
   * ::graphql-data [[graphql-data-interceptor]]
   * ::status-conversion [[status-conversion-interceptor]]
   * ::missing-query [[missing-query-interceptor]]
-  * ::query-paraser [[query-parser-interceptor]]
+  * ::query-parser [[query-parser-interceptor]]
   * ::disallow-subscriptions [[disallow-subscriptions-interceptor]]
   * ::inject-app-context [[inject-app-context-interceptor]]
   * ::query-executor [[query-executor-handler]] or [[async-query-executor-handler]]

--- a/test/com/walmartlabs/lacinia/pedestal_test.clj
+++ b/test/com/walmartlabs/lacinia/pedestal_test.clj
@@ -32,7 +32,19 @@
         (send-json-request :post
                            {:query "{ echo(value: \"hello\") { value method }}"}
                            "text/plain")]
-    (is (= {:body {:message "Request content type must be application/graphql or application/json."}
+    (is (= {:body {:errors [{:message "Request content type must be application/graphql or application/json."}]}
+            :status 400}
+           (select-keys response [:status :body])))))
+
+(deftest missing-query
+  (let [response (send-json-request :get nil nil)]
+    (is (= {:body {:errors [{:message "Query parameter 'query' is missing or blank."}]}
+            :status 400}
+           (select-keys response [:status :body])))))
+
+(deftest empty-body
+  (let [response (send-json-request :post nil "application/json")]
+    (is (= {:body {:errors [{:message "Request body is empty."}]}
             :status 400}
            (select-keys response [:status :body])))))
 

--- a/test/com/walmartlabs/lacinia/pedestal_test.clj
+++ b/test/com/walmartlabs/lacinia/pedestal_test.clj
@@ -105,3 +105,9 @@
   (let [response (client/get "http://localhost:8888/" {:throw-exceptions false})]
     (is (= 200 (:status response)))
     (is (str/includes? (:body response) "<html>"))))
+
+(deftest forbids-subscriptions
+  (let [response (send-request :post "subscription { ping(message: \"gnip\") { message }}")]
+    (is (= {:body {:errors [{:message "Subscription queries must be processed by the WebSockets endpoint."}]}
+            :status 400}
+           (select-keys response [:status :body])))))


### PR DESCRIPTION
This now covers all errors, even before the query is parsed, prepared, and executed.

I also added a missing test related to disallow-subscriptions, and found a bug in the interceptor, also fixed.