### PR TITLE
Fix content-type charset parsing

### DIFF
--- a/dev-resources/com/walmartlabs/lacinia/test_utils.clj
+++ b/dev-resources/com/walmartlabs/lacinia/test_utils.clj
@@ -98,7 +98,7 @@
 
 (defn send-json-request
   ([method json]
-   (send-json-request method json "application/json"))
+   (send-json-request method json "application/json; charset=utf-8"))
   ([method json content-type]
    (-> {:method method
         :url "http://localhost:8888/graphql"

--- a/src/com/walmartlabs/lacinia/pedestal.clj
+++ b/src/com/walmartlabs/lacinia/pedestal.clj
@@ -38,15 +38,16 @@
   "Parse `s` as an RFC 2616 media type.
   Originally from http-kit"
   [s]
-  (if-let [m (re-matches #"\s*(([^/]+)/([^ ;]+))\s*(\s*;.*)?" (str s))]
-    {:content-type (keyword (nth m 1))
+  (if-let [[_ type _ _ raw-params] (re-matches #"\s*(([^/]+)/([^ ;]+))\s*(\s*;.*)?" (str s))]
+    {:content-type (keyword type)
      :content-type-params
-     (->> (str/split (str (nth m 4)) #"\s*;\s*")
-       (identity)
-       (remove str/blank?)
-       (map #(str/split % #"="))
-       (mapcat (fn [[k v]] [(keyword (str/lower-case k)) (str/trim v)]))
-       (apply hash-map))}))
+     (->> (str/split (str raw-params) #"\s*;\s*")
+        (keep identity)
+        (remove str/blank?)
+        (map #(str/split % #"="))
+        (mapcat (fn [[k v]] [(keyword (str/lower-case k)) (str/trim v)]))
+        (apply hash-map))}))
+
 
 (defn content-type
   "Gets the content-type of a request. (without encoding)"

--- a/src/com/walmartlabs/lacinia/pedestal.clj
+++ b/src/com/walmartlabs/lacinia/pedestal.clj
@@ -35,8 +35,7 @@
   {:errors [{:message message}]})
 
 (defn parse-content-type
-  "Parse `s` as an RFC 2616 media type.
-  Originally from http-kit"
+  "Parse `s` as an RFC 2616 media type."
   [s]
   (if-let [[_ type _ _ raw-params] (re-matches #"\s*(([^/]+)/([^ ;]+))\s*(\s*;.*)?" (str s))]
     {:content-type (keyword type)

--- a/test/com/walmartlabs/lacinia/parse_test.clj
+++ b/test/com/walmartlabs/lacinia/parse_test.clj
@@ -1,0 +1,47 @@
+(ns com.walmartlabs.lacinia.parse-test
+  (:require
+    [clojure.test :refer :all]
+    [com.walmartlabs.lacinia.pedestal :as lp]))
+
+
+(deftest parse-test
+  (are [s r]
+    (= r (lp/parse-content-type s))
+
+    "application/json"
+    {:content-type :application/json
+     :content-type-params {}}
+
+    "application/json;q=0.3"
+    {:content-type :application/json
+     :content-type-params {:q "0.3"}}
+
+    "text/html; charset=UTF-8"
+    {:content-type :text/html
+     :content-type-params {:charset "UTF-8"}}
+
+    "application/edn;CharSet=UTF-32"
+    {:content-type :application/edn
+     :content-type-params {:charset "UTF-32"}}
+
+    "multipart/form-data; boundary=x; charset=US-ASCII"
+    {:content-type :multipart/form-data
+     :content-type-params {:boundary "x", :charset "US-ASCII"}}
+
+    " application/json "
+    {:content-type :application/json
+     :content-type-params {}}
+
+    " application/json;  charset=UTF-16 "
+    {:content-type :application/json
+     :content-type-params {:charset "UTF-16"}}
+
+    "text/html; charset=ISO-8859-4"
+    {:content-type :text/html
+     :content-type-params {:charset "ISO-8859-4"}}
+
+    ""
+    nil
+
+    nil
+    nil))


### PR DESCRIPTION
Before content-type header was not parsed and so requests with encoding parameter, were discarded as having faulty content-type.

This PR implements parser for content-type (from Aleph-project) and changes multimethods to use keywords instead of strings.

Fixes #18 