### PR TITLE
Allow compiled schema to be provided indirectly, as a function that returns the schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.4.0 -- UNRELEASED
 
+The compiled-schema passed to `com.walmartlabs.lacinia.pedestal/pedestal-service` may now
+be a function that _returns_ the compiled schema, which is useful when during testing
+and development.
+
 ## 0.3.0 -- 7 Aug 2017
 
 Added support for GraphQL subscriptions!

--- a/README.md
+++ b/README.md
@@ -56,6 +56,17 @@ $ curl localhost:8888/graphql -X POST -H "content-type: application/graphql" -d 
 {"data":{"hello":"world"}}
 ```
 
+## Development Mode
+
+When developing an application, it is desirable to be able to change the schema
+without restarting.
+Lacinia-Pedestal supports this: in the above example, the schema passed to
+`pedestal-service` could be a _function_ that returns the compiled schema.
+It could even be a Var containing the function that returns the compiled schema.
+
+In this way, the Pedestal stack continues to run, but each request rebuilds
+the compiled schema based on the latest code you've loaded into the REPL.
+
 ### GraphiQL
 
 The GraphiQL packaged inside the library is built using `npm`, from

--- a/project.clj
+++ b/project.clj
@@ -4,10 +4,10 @@
   :license {:name "Apache Software License 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [com.walmartlabs/lacinia "0.20.0"]
-                 [com.fasterxml.jackson.core/jackson-core "2.9.0"]
-                 [io.pedestal/pedestal.service "0.5.2"]
-                 [io.pedestal/pedestal.jetty "0.5.2"]
+                 [com.walmartlabs/lacinia "0.21.0"]
+                 [com.fasterxml.jackson.core/jackson-core "2.9.2"]
+                 [io.pedestal/pedestal.service "0.5.3"]
+                 [io.pedestal/pedestal.jetty "0.5.3"]
                  [com.stuartsierra/dependency "0.2.0"]]
   :profiles
   {:dev {:dependencies [[clj-http "2.3.0"]

--- a/test/com/walmartlabs/lacinia/indirect_schema_test.clj
+++ b/test/com/walmartlabs/lacinia/indirect_schema_test.clj
@@ -1,0 +1,62 @@
+(ns com.walmartlabs.lacinia.indirect-schema-test
+  (:require
+    [clojure.test :refer [deftest is use-fixtures]]
+    [com.walmartlabs.lacinia.pedestal :as lp]
+    [clj-http.client :as client]
+    [clojure.string :as str]
+    [com.walmartlabs.lacinia.test-utils
+     :refer [test-server-fixture subscriptions-fixture
+             send-json-request
+             send-init send-data
+             expect-message *ping-subscribes *ping-cleanups
+             *subscriber-id]]))
+
+(use-fixtures :once (test-server-fixture {:graphiql true
+                                          :indirect-schema true
+                                          :subscriptions true
+                                          :keep-alive-ms 200}))
+
+(use-fixtures :each subscriptions-fixture)
+
+(deftest standard-json-request
+  (let [response
+        (send-json-request :post
+                           {:query "{ echo(value: \"hello\") { value method }}"})]
+    (is (= 200 (:status response)))
+    (is (= {:data {:echo {:method "post"
+                          :value "hello"}}}
+           (:body response)))))
+
+(deftest short-subscription
+  (send-init)
+  (expect-message {:type "connection_ack"})
+
+  ;; There's an observability issue with core.async, of course, just as there's an observability
+  ;; problem inside pure and lazy functions. We have to draw conclusions from some global side-effects
+  ;; we've introduced.
+
+  (is (= @*ping-subscribes @*ping-cleanups)
+      "Any prior subscribes have been cleaned up.")
+
+  (let [id (swap! *subscriber-id inc)]
+    (send-data {:id id
+                :type :start
+                :payload
+                {:query "subscription { ping(message: \"short\", count: 2 ) { message }}"}})
+
+    (expect-message {:id id
+                     :payload {:data {:ping {:message "short #1"}}}
+                     :type "data"})
+
+    (is (> @*ping-subscribes @*ping-cleanups)
+        "A subscribe is active, but has not been cleaned up.")
+
+    (expect-message {:id id
+                     :payload {:data {:ping {:message "short #2"}}}
+                     :type "data"})
+
+    (expect-message {:id id
+                     :type "complete"})
+
+    (is (= @*ping-subscribes @*ping-cleanups)
+        "The completed subscription has been cleaned up.")))


### PR DESCRIPTION
This has been requested internally and externally: allow the schema to be updated without a server restart, for REPL-oriented development.

A large chunk of this was refactoring so that the subscriptions test code could be reused for the (trival) case where the compiled schema for a subscription was indirect.