### PR TITLE
New function: splice - injects an interceptor w/o affecting existing interceptor's dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.4.0 -- UNRELEASED
 
+
+Added `com.walmartlabs.lacinia.pedestal.interceptors/splice`, which is
+used to substitute an existing interceptor with a replacement.
+
 ## 0.3.0 -- 7 Aug 2017
 
 Added support for GraphQL subscriptions!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.4.0 -- UNRELEASED
+
 ## 0.3.0 -- 7 Aug 2017
 
 Added support for GraphQL subscriptions!

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.walmartlabs/lacinia-pedestal "0.3.0"
+(defproject com.walmartlabs/lacinia-pedestal "0.4.0"
   :description "Pedestal infrastructure supporting Lacinia GraphQL"
   :url "https://github.com/walmartlabs/pedestal-lacinia"
   :license {:name "Apache Software License 2.0"

--- a/src/com/walmartlabs/lacinia/pedestal/interceptors.clj
+++ b/src/com/walmartlabs/lacinia/pedestal/interceptors.clj
@@ -66,7 +66,7 @@
 (defn splice
   "Overwrites an existing interceptor in the map with a replacement interceptor.
 
-  Throws an exception is the interceptor does not already exist.
+  Throws an exception if the interceptor does not already exist.
 
   The replacement's dependencies are merged with the dependency it is replacing: this
   ensures that interceptor ordering is not affected, even if it was based on transitive

--- a/src/com/walmartlabs/lacinia/pedestal/interceptors.clj
+++ b/src/com/walmartlabs/lacinia/pedestal/interceptors.clj
@@ -44,12 +44,12 @@
   (let [reducer (fn [g dep-name interceptor]
                   (reduce #(d/depend %1 dep-name %2)
                           g
-                          (-> interceptor meta ::dependencies)))]
+                          (dependencies interceptor)))]
     (->> dependency-map
          (reduce-kv reducer (d/graph))
          ;; Note: quietly ignore dependencies to unknown nodes, which is a feature
          ;; (you can remove an interceptor entirely even if other interceptors depend
-         ;; on it).
+         ;; on it) ... though probably better to use splice now.
          d/topo-sort
          (map #(get dependency-map %))
          ;; When dealing with dependencies, you might replace a dependency with
@@ -62,3 +62,22 @@
   of each interceptor.  This can then be passed to [[order-by-dependency]]."
   [interceptors]
   (zipmap (map :name interceptors) interceptors))
+
+(defn splice
+  "Overwrites an existing interceptor in the map with a replacement interceptor.
+
+  Throws an exception is the interceptor does not already exist.
+
+  The replacement's dependencies are merged with the dependency it is replacing: this
+  ensures that interceptor ordering is not affected, even if it was based on transitive
+  dependencies through the replaced interceptor."
+  {:added "0.4.0"}
+  [dependency-map interceptor-name replacement]
+  (update dependency-map interceptor-name
+          (fn [existing]
+            (when (nil? existing)
+              (throw (ex-info "Unknown interceptor for splice."
+                              {:dependency-map dependency-map
+                               :interceptor-name interceptor-name})))
+
+            (ordered-after replacement (dependencies existing)))))

--- a/test/com/walmartlabs/lacinia/pedestal/interceptors_test.clj
+++ b/test/com/walmartlabs/lacinia/pedestal/interceptors_test.clj
@@ -1,0 +1,36 @@
+(ns com.walmartlabs.lacinia.pedestal.interceptors-test
+  (:require
+    [clojure.test :refer [deftest is]]
+    [com.walmartlabs.lacinia.pedestal.interceptors
+     :refer [ordered-after order-by-dependency as-dependency-map dependencies splice]]))
+
+(defn ^:private ordered-names
+  [dependency-map]
+  (->> dependency-map order-by-dependency (map :name)))
+
+(deftest orders-by-dependency
+  (let [dm (as-dependency-map [(ordered-after {:name :later} [:earlier])
+                               {:name :earlier}])]
+    (is (= [:earlier :later]
+           (ordered-names dm)))))
+
+(deftest splice-maintains-order
+  (let [dm (as-dependency-map [{:name :moe}
+                               (ordered-after {:name :larry} [:moe])
+                               (ordered-after {:name :curly} [:moe :larry])])
+        dm' (splice dm :curly (ordered-after {:name :shemp} [:harpo]))]
+    ;; Explicitly OK that :harpo doesn't exist, for better or worse.
+    (is (= [:moe :larry :shemp]
+           (ordered-names dm')))
+    (is (= #{:harpo :moe :larry}
+           (-> dm' :curly dependencies)))))
+
+(deftest spliced-interceptor-must-exist
+  (let [dm (as-dependency-map [{:name :moe}
+                               (ordered-after {:name :larry} [:moe])
+                               (ordered-after {:name :curly} [:moe :larry])])
+        e (is (thrown? Throwable (splice dm :groucho {})))]
+    (is (= "Unknown interceptor for splice." (.getMessage e)))
+    (is (= {:dependency-map dm
+            :interceptor-name :groucho}
+           (ex-data e)))))


### PR DESCRIPTION
It is sometimes desirable to replace an interceptor with a new interceptor that has its own dependencies (on other interceptors) BUT an overall pipeline often relies on transitive dependencies for proper ordering.

`splice` is pretty much a smarter version of `assoc` for a dependency map, that merges the dependencies of the original and replacement interceptors.  It also checks that the replaced interceptor actually exists.

