### PR TITLE
Make it responsibility of caller to invoke io.pedestal.http/create-server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 ## 0.5.0 -- UNRELEASED
 
-The service map created by `com.walmartlabs.lacinia.pedestal/pedestal-service` is not longer
-passed to `io.pedestal.http/create-server`; this is now the responsibility of the caller.
+New function `com.walmartlabs.lacinia.pedestal/service-map` is now preferred
+over `pedestal-service` (which has been deprecated).
+`service-map` does *not* create the server; that is now the responsibility
+of the§ calling code,
+which makes it far easier to customize the service map before creating a server
+from it.
 
 ## 0.4.0 -- 24 Oct 2017
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,11 @@
 New function `com.walmartlabs.lacinia.pedestal/service-map` is now preferred
 over `pedestal-service` (which has been deprecated).
 `service-map` does *not* create the server; that is now the responsibility
-of the§ calling code,
+of the calling code,
 which makes it far easier to customize the service map before creating a server
 from it.
+
+[Closed Issues](https://github.com/walmartlabs/lacinia-pedestal/milestone/4?closed=1)
 
 ## 0.4.0 -- 24 Oct 2017
 
@@ -15,6 +17,8 @@ and development.
 
 Added `com.walmartlabs.lacinia.pedestal.interceptors/splice`, which is
 used to substitute an existing interceptor with a replacement.
+
+[Closed Issues](https://github.com/walmartlabs/lacinia-pedestal/milestone/3?closed=1)
 
 ## 0.3.0 -- 7 Aug 2017
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.5.0 -- UNRELEASED
+
+The service map created by `com.walmartlabs.lacinia.pedestal/pedestal-service` is not longer
+passed to `io.pedestal.http/create-server`; this is now the responsibility of the caller.
+
 ## 0.4.0 -- 24 Oct 2017
 
 The compiled-schema passed to `com.walmartlabs.lacinia.pedestal/pedestal-service` may now

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ as [Apollo GraphQL](https://github.com/apollographql/subscriptions-transport-ws)
 ## Usage
 
 For a basic Pedestal server, simply supply a compiled Lacinia schema to
-the `com.walmartlabs.lacinia.pedestal/pedestal-service` function to.
+the `com.walmartlabs.lacinia.pedestal/service-map` function to
 generate a service, then invoke `io.pedestal.http/create-server` and `/start`.
 
 ```clojure
@@ -36,7 +36,7 @@ generate a service, then invoke `io.pedestal.http/create-server` and `/start`.
                               {:type 'String
                                :resolve (constantly "world")}}}))
 
-(def service (lacinia/pedestal-service hello-schema {:graphiql true}))
+(def service (lacinia/service-map hello-schema {:graphiql true}))
 
 ;; This is an adapted service map, that can be started and stopped
 ;; From the REPL you can call server/start and server/stop on this service

--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@ A library that adds the
 Lacinia-Pedestal also supports GraphQL subscriptions, using the same protocol
 as [Apollo GraphQL](https://github.com/apollographql/subscriptions-transport-ws).
 
-[Lacinia-Pedestal Manual](http://lacinia-pedestal.readthedocs.io/en/latest/)
-
+[Lacinia-Pedestal Manual](http://lacinia-pedestal.readthedocs.io/en/latest/) |
 [API Documentation](http://walmartlabs.github.io/lacinia-pedestal/)
 
 ## Usage

--- a/dev-resources/com/walmartlabs/lacinia/test_utils.clj
+++ b/dev-resources/com/walmartlabs/lacinia/test_utils.clj
@@ -55,7 +55,7 @@
                    (cond-> (:indirect-schema options) constantly))
         options' (merge options
                         (options-builder schema))]
-    (lp/pedestal-service schema options')))
+    (lp/service-map schema options')))
 
 (defn test-server-fixture
   "Starts up the test server as a fixture."

--- a/dev-resources/com/walmartlabs/lacinia/test_utils.clj
+++ b/dev-resources/com/walmartlabs/lacinia/test_utils.clj
@@ -65,8 +65,9 @@
    (fn [f]
      (reset! *ping-subscribes 0)
      (reset! *ping-cleanups 0)
-     (let [service (make-service options options-builder)]
-       (http/start service)
+     (let [service (-> (make-service options options-builder)
+                       http/create-server
+                       http/start)]
        (try
          (f)
          (finally

--- a/docs/_examples/basic-setup.edn
+++ b/docs/_examples/basic-setup.edn
@@ -2,7 +2,7 @@
   (:require
     [clojure.edn :as edn]
     [clojure.java.io :as io]
-    [com.walmartlabs.lacinia.pedestal :refer [pedestal-service]]
+    [com.walmartlabs.lacinia.pedestal :refer [service-map]]
     [com.walmartlabs.lacinia.schema :as schema]
     [com.walmartlabs.lacinia.util :as util]
     [io.pedestal.http :as http]))
@@ -21,6 +21,6 @@
       schema/compile))
 
 (def service (-> (hello-schema)
-                 (pedestal-service {:graphiql true})
+                 (service-map {:graphiql true})
                  http/create-server
                  http/start))

--- a/docs/_examples/basic-setup.edn
+++ b/docs/_examples/basic-setup.edn
@@ -2,7 +2,7 @@
   (:require
     [clojure.edn :as edn]
     [clojure.java.io :as io]
-    [com.walmartlabs.lacinia.pedestal :refer [pedestal-service]
+    [com.walmartlabs.lacinia.pedestal :refer [pedestal-service]]
     [com.walmartlabs.lacinia.schema :as schema]
     [com.walmartlabs.lacinia.util :as util]
     [io.pedestal.http :as http]))
@@ -11,7 +11,8 @@
   [context args value]
   "Hello, Clojurians!")
 
-(def ^:private hello-schema
+(defn ^:private hello-schema
+  []
   (-> "hello-world-schema.edn"
       io/resource
       slurp
@@ -19,6 +20,7 @@
       (util/attach-resolvers {:resolve-hello resolve-hello})
       schema/compile))
 
-(def service (-> hello-schema
+(def service (-> (hello-schema)
                  (pedestal-service {:graphiql true})
+                 http/create-server
                  http/start))

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -2,3 +2,7 @@
 div.highlight-clojure {
   clear: right;
 }
+
+a.headerlink {
+  float: right;
+}

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -24,7 +24,7 @@ At the end of this, an instance of `Jetty <http://www.eclipse.org/jetty/>`_ is l
 The GraphQL endpoint will be at ``http://localhost:8888/graphql`` and the GraphIQL client will be at
 ``http://localhost:8888/``.
 
-The options map provided to ``pedestal-service`` allow any number of features of Lacinia-Pedestal
+The options map provided to ``pedestal-service`` allow a number of features of Lacinia-Pedestal
 to be configured or customized.
 
 Lacinia-Pedestal supports GET and POSTs in a number of different formats.

--- a/docs/subscriptions.rst
+++ b/docs/subscriptions.rst
@@ -36,9 +36,15 @@ Most commonly, a streamer will subscribe to some external feed such as a JMS or 
 a `core.async pub <http://clojure.github.io/core.async/#clojure.core.async/pub>`_ or channel.
 
 When a streamer passes nil to the callback, a clean shutdown of the subscription occurs; the
-client is sent a completion message (otherwise, it might attempt to reconnect).
+client is sent a completion message.
+The completion message informs the client that the stream of events has completed, and that it
+should not attempt to reconnect.
 
-The cleanup function is invoked when the client closes the subscription, then the connection from
+The definition of "completed" here is entirely up to the application.
+For example, a field argument could specify the maximum number of values to stream, and the
+streamer can pass nil after sufficient values are streamed.
+
+The cleanup function is invoked when the client closes the subscription, when the connection from
 the client is lost due to a network partition, or when the streamer passes nil to the callback.
 
 Configuration
@@ -64,7 +70,7 @@ Endpoint
 --------
 
 Subscriptions are processed on a second endpoint; normal requests continue to be sent to ``/graphql``, but
-Subscription requests must use ``/graphql-ws``.
+subscription requests must use ``/graphql-ws``.
 
 The ``/graphql-ws`` endpoint does not handle ordinary requests; instead it is used only to establish the
 WebSocket connection.

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.walmartlabs/lacinia-pedestal "0.4.0"
+(defproject com.walmartlabs/lacinia-pedestal "0.5.0"
   :description "Pedestal infrastructure supporting Lacinia GraphQL"
   :url "https://github.com/walmartlabs/pedestal-lacinia"
   :license {:name "Apache Software License 2.0"

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Apache Software License 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [com.walmartlabs/lacinia "0.22.1"]
+                 [com.walmartlabs/lacinia "0.23.0-rc-1"]
                  [com.fasterxml.jackson.core/jackson-core "2.9.2"]
                  [io.pedestal/pedestal.service "0.5.3"]
                  [io.pedestal/pedestal.jetty "0.5.3"]

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Apache Software License 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [com.walmartlabs/lacinia "0.22.0"]
+                 [com.walmartlabs/lacinia "0.22.1"]
                  [com.fasterxml.jackson.core/jackson-core "2.9.2"]
                  [io.pedestal/pedestal.service "0.5.3"]
                  [io.pedestal/pedestal.jetty "0.5.3"]

--- a/resources/graphiql/package-lock.json
+++ b/resources/graphiql/package-lock.json
@@ -1,0 +1,208 @@
+{
+  "name": "graphiql-packaged",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "asap": {
+      "version": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+    },
+    "codemirror": {
+      "version": "https://registry.npmjs.org/codemirror/-/codemirror-5.28.0.tgz",
+      "integrity": "sha1-KXjZKA1nE1Gk9XN9BrvWgaD9b4M="
+    },
+    "codemirror-graphql": {
+      "version": "https://registry.npmjs.org/codemirror-graphql/-/codemirror-graphql-0.6.11.tgz",
+      "integrity": "sha1-eV76OTNSOBWlJF7v6NaDHTxK0CY=",
+      "requires": {
+        "graphql-language-service-interface": "https://registry.npmjs.org/graphql-language-service-interface/-/graphql-language-service-interface-0.0.19.tgz",
+        "graphql-language-service-parser": "https://registry.npmjs.org/graphql-language-service-parser/-/graphql-language-service-parser-0.0.15.tgz"
+      }
+    },
+    "core-js": {
+      "version": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+    },
+    "create-react-class": {
+      "version": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.0.tgz",
+      "integrity": "sha1-q0SEl8JlZuHilBPogyB9V8/nvtQ=",
+      "requires": {
+        "fbjs": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.14.tgz",
+        "loose-envify": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+      }
+    },
+    "encoding": {
+      "version": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "requires": {
+        "iconv-lite": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz"
+      }
+    },
+    "fbjs": {
+      "version": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.14.tgz",
+      "integrity": "sha1-0dviviVMNakeCfMfnNUKQLKg7Rw=",
+      "requires": {
+        "core-js": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+        "isomorphic-fetch": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+        "loose-envify": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "promise": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+        "setimmediate": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+        "ua-parser-js": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.14.tgz"
+      }
+    },
+    "graphiql": {
+      "version": "https://registry.npmjs.org/graphiql/-/graphiql-0.11.2.tgz",
+      "integrity": "sha1-f3hkVSw0CrT+b1eM4/cZeQXUKds=",
+      "requires": {
+        "codemirror": "https://registry.npmjs.org/codemirror/-/codemirror-5.28.0.tgz",
+        "codemirror-graphql": "https://registry.npmjs.org/codemirror-graphql/-/codemirror-graphql-0.6.11.tgz",
+        "marked": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz"
+      }
+    },
+    "graphql": {
+      "version": "https://registry.npmjs.org/graphql/-/graphql-0.10.5.tgz",
+      "integrity": "sha1-yb4Xyivf29E0B3/9m7qki4vs0pg=",
+      "requires": {
+        "iterall": "https://registry.npmjs.org/iterall/-/iterall-1.1.1.tgz"
+      }
+    },
+    "graphql-language-service-config": {
+      "version": "https://registry.npmjs.org/graphql-language-service-config/-/graphql-language-service-config-0.0.17.tgz",
+      "integrity": "sha1-NrWpkGwL8NNW0xt1gwWPm4XReT4=",
+      "requires": {
+        "graphql-language-service-types": "https://registry.npmjs.org/graphql-language-service-types/-/graphql-language-service-types-0.0.21.tgz"
+      }
+    },
+    "graphql-language-service-interface": {
+      "version": "https://registry.npmjs.org/graphql-language-service-interface/-/graphql-language-service-interface-0.0.19.tgz",
+      "integrity": "sha1-xY+nvZXS8w4z4Ek3oaLACpdAkm4=",
+      "requires": {
+        "graphql": "https://registry.npmjs.org/graphql/-/graphql-0.10.5.tgz",
+        "graphql-language-service-config": "https://registry.npmjs.org/graphql-language-service-config/-/graphql-language-service-config-0.0.17.tgz",
+        "graphql-language-service-parser": "https://registry.npmjs.org/graphql-language-service-parser/-/graphql-language-service-parser-0.0.15.tgz",
+        "graphql-language-service-types": "https://registry.npmjs.org/graphql-language-service-types/-/graphql-language-service-types-0.0.21.tgz",
+        "graphql-language-service-utils": "https://registry.npmjs.org/graphql-language-service-utils/-/graphql-language-service-utils-0.0.17.tgz"
+      }
+    },
+    "graphql-language-service-parser": {
+      "version": "https://registry.npmjs.org/graphql-language-service-parser/-/graphql-language-service-parser-0.0.15.tgz",
+      "integrity": "sha1-/WSv2Ic2JPo8SlgxoI3pzNbMUYI=",
+      "requires": {
+        "graphql-language-service-types": "https://registry.npmjs.org/graphql-language-service-types/-/graphql-language-service-types-0.0.21.tgz"
+      }
+    },
+    "graphql-language-service-types": {
+      "version": "https://registry.npmjs.org/graphql-language-service-types/-/graphql-language-service-types-0.0.21.tgz",
+      "integrity": "sha1-uUUzZvyJhXZQNL80BW/pNgOiS4I=",
+      "requires": {
+        "graphql": "https://registry.npmjs.org/graphql/-/graphql-0.10.5.tgz"
+      }
+    },
+    "graphql-language-service-utils": {
+      "version": "https://registry.npmjs.org/graphql-language-service-utils/-/graphql-language-service-utils-0.0.17.tgz",
+      "integrity": "sha1-qLkeyoDGqloNRhoLu2MxeYb5uYk=",
+      "requires": {
+        "graphql": "https://registry.npmjs.org/graphql/-/graphql-0.10.5.tgz",
+        "graphql-language-service-types": "https://registry.npmjs.org/graphql-language-service-types/-/graphql-language-service-types-0.0.21.tgz"
+      }
+    },
+    "iconv-lite": {
+      "version": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz",
+      "integrity": "sha1-I9hlaxaq5nQqwpcy6o8DNqR4nPI="
+    },
+    "is-stream": {
+      "version": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "isomorphic-fetch": {
+      "version": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "requires": {
+        "node-fetch": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.1.tgz",
+        "whatwg-fetch": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz"
+      }
+    },
+    "iterall": {
+      "version": "https://registry.npmjs.org/iterall/-/iterall-1.1.1.tgz",
+      "integrity": "sha1-9/CvEemgTsZCYmD1AZ2fzKTVAhQ="
+    },
+    "js-tokens": {
+      "version": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+    },
+    "loose-envify": {
+      "version": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "requires": {
+        "js-tokens": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+      }
+    },
+    "marked": {
+      "version": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
+      "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc="
+    },
+    "node-fetch": {
+      "version": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.1.tgz",
+      "integrity": "sha1-iZyz0KPJL5UsR/G4dvTIrqvUANU=",
+      "requires": {
+        "encoding": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+        "is-stream": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
+      }
+    },
+    "object-assign": {
+      "version": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "promise": {
+      "version": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
+      "requires": {
+        "asap": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz"
+      }
+    },
+    "prop-types": {
+      "version": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.10.tgz",
+      "integrity": "sha1-J5ffwxJhguOpXj37suiT3ddFYVQ=",
+      "requires": {
+        "fbjs": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.14.tgz",
+        "loose-envify": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz"
+      }
+    },
+    "react": {
+      "version": "https://registry.npmjs.org/react/-/react-15.6.1.tgz",
+      "integrity": "sha1-uqhDTsZ4C96ZfNw4C3nNM7ljk98=",
+      "requires": {
+        "create-react-class": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.0.tgz",
+        "fbjs": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.14.tgz",
+        "loose-envify": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "prop-types": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.10.tgz"
+      }
+    },
+    "react-dom": {
+      "version": "https://registry.npmjs.org/react-dom/-/react-dom-15.6.1.tgz",
+      "integrity": "sha1-LLDtQZEDjlPCCes6eaI+Kkz5lHA=",
+      "requires": {
+        "fbjs": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.14.tgz",
+        "loose-envify": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "prop-types": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.10.tgz"
+      }
+    },
+    "setimmediate": {
+      "version": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+    },
+    "ua-parser-js": {
+      "version": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.14.tgz",
+      "integrity": "sha1-EQ1T+kw/MmwSEpK76skE0uAzh8o="
+    },
+    "whatwg-fetch": {
+      "version": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+      "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+    }
+  }
+}

--- a/src/com/walmartlabs/lacinia/pedestal.clj
+++ b/src/com/walmartlabs/lacinia/pedestal.clj
@@ -404,26 +404,25 @@
          :or {graphiql false
               subscriptions false
               port 8888
-              env :dev}} options
+              env :dev
+              create? true}} options
         routes (or (:routes options)
                    (route/expand-routes (graphql-routes compiled-schema options)))]
-    (->
-      {:env env
-       ::http/routes routes
-       ::http/port port
-       ::http/type :jetty
-       ::http/join? false}
-      (cond->
-        subscriptions
-        (assoc-in [::http/container-options :context-configurator]
-                  ;; The listener-fn is responsible for creating the listener; it is passed
-                  ;; the request, response, and the ws-map. In sample code, the ws-map
-                  ;; has callbacks such as :on-connect and :on-text, but in our scenario
-                  ;; the callbacks are created by the listener-fn, so the value is nil.
-                  #(ws/add-ws-endpoints % {"/graphql-ws" nil}
-                                        {:listener-fn
-                                         (subscriptions/listener-fn-factory compiled-schema options)}))
+    (cond-> {:env env
+             ::http/routes routes
+             ::http/port port
+             ::http/type :jetty
+             ::http/join? false}
 
-        graphiql
-        (assoc ::http/resource-path "graphiql"))
-      http/create-server)))
+      subscriptions
+      (assoc-in [::http/container-options :context-configurator]
+                ;; The listener-fn is responsible for creating the listener; it is passed
+                ;; the request, response, and the ws-map. In sample code, the ws-map
+                ;; has callbacks such as :on-connect and :on-text, but in our scenario
+                ;; the callbacks are created by the listener-fn, so the value is nil.
+                #(ws/add-ws-endpoints % {"/graphql-ws" nil}
+                                      {:listener-fn
+                                       (subscriptions/listener-fn-factory compiled-schema options)}))
+
+      graphiql
+      (assoc ::http/resource-path "graphiql"))))

--- a/test/com/walmartlabs/lacinia/pedestal_graphiql_disabled_test.clj
+++ b/test/com/walmartlabs/lacinia/pedestal_graphiql_disabled_test.clj
@@ -3,13 +3,15 @@
     [com.walmartlabs.lacinia.pedestal :as lp]
     [clojure.test :refer [deftest is are use-fixtures]]
     [io.pedestal.http :as http]
-    [clj-http.client :as client]))
+    [clj-http.client :as client]
+    [com.walmartlabs.lacinia.schema :as schema]))
 
 (use-fixtures :once
   (fn [f]
-    (let [
-          service (lp/pedestal-service {} {:graphiql false})]
-      (http/start service)
+    (let [empty-schema (schema/compile {})
+          service (-> (lp/pedestal-service empty-schema {:graphiql false})
+                      http/create-server
+                      http/start)]
       (try
         (f)
         (finally


### PR DESCRIPTION
This came up in discussion on the Pedestal slack.  Having `pedestal-service` create the server makes it awkward to add additional routing or other configuration before creating the server.