### PR TITLE
Fixing typo in app context getter for execute-operation

### DIFF
--- a/src/com/walmartlabs/lacinia/pedestal/subscriptions.clj
+++ b/src/com/walmartlabs/lacinia/pedestal/subscriptions.clj
@@ -252,7 +252,7 @@
   (let [ch (chan 1)]
     (-> context
         :request
-        :lacina-app-context
+        :lacinia-app-context
         (assoc constants/parsed-query-key parsed-query)
         executor/execute-query
         (resolve/on-deliver! (fn [response]


### PR DESCRIPTION
Hi,

This typo means that if you perform an operation over the websocket (e.g. a query, or a mutation) the app context doesn't get injected. Fixing it means the app-context is injected properly.

Cheers,
Oliy