### PR TITLE
Report parse/validation exceptions in subscription requests

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [com.walmartlabs/lacinia "0.23.0"]
-                 [com.fasterxml.jackson.core/jackson-core "2.9.2"]
+                 [com.fasterxml.jackson.core/jackson-core "2.9.3"]
                  [io.pedestal/pedestal.service "0.5.3"]
                  [io.pedestal/pedestal.jetty "0.5.3"]
                  [com.stuartsierra/dependency "0.2.0"]]


### PR DESCRIPTION
Follow the Apollo spec better
Simplify, and make it easier to expose the underlying error map

This also avoids a problem where an exception with a nil message could cause a cascade exception.