### PR TITLE
Adding app-context for service-map docstring

### DIFF
--- a/src/com/walmartlabs/lacinia/pedestal.clj
+++ b/src/com/walmartlabs/lacinia/pedestal.clj
@@ -466,6 +466,9 @@
   : If enabled, then support for WebSocket-based subscriptions is added.
   : See [[listener-fn-factory]] for further options related to subscriptions.
 
+  :app-context
+  : The base application context provided to Lacinia when executing a query.
+
   :subscriptions-path (default: \"/graphql-ws\")
   : If subscriptions are enabled, the path at which to service GraphQL websocket requests.
     This must be a distinct path (not the same as the main path or the GraphiQL IDE path).


### PR DESCRIPTION
This just adds documentation for the `:app-context` option key to the `(service-map)` docstring. It's already present in another few places, but I think repeating it here will make it a little more obvious about how to add it in relative to the example code in the docs and README.md.