### PR TITLE
Deprecate and replace com.walmartlabs.lacinia.pedestal.interceptors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.7.0 -- UNRELEASED
+
+The `com.walmartlabs.lacina.pedestal.interceptors` namespace has been deprecated; it will be removed
+in the 0.8.0 release.
+Instead, use the new `inject` function, which adds (or replaces) an interceptor to a seq of
+interceptors.
+
+The `interceptors` namespace, and other functions related to interceptor maps, will be removed
+in the 0.8.0 release.  All functions scheduled for removal have been so marked in their docstrings.
+
 ## 0.6.0 -- UNRELEASED
 
 It is now possible to configure the paths used to access the GraphQL endpoint and
@@ -34,7 +44,9 @@ used to substitute an existing interceptor with a replacement.
 ## 0.3.0 -- 7 Aug 2017
 
 Added support for GraphQL subscriptions!
-Subscriptions are patterned after [Apollo GraphQL](http://dev.apollodata.com/tools/graphql-subscriptions/index.html).
+Subscriptions are patt
+
+erned after [Apollo GraphQL](http://dev.apollodata.com/tools/graphql-subscriptions/index.html).
 lacinia-pedestal should be a drop-in replacement for Apollo GraphQL server.
 
 The default interceptor stack has been reordered, slightly.

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.walmartlabs/lacinia-pedestal "0.6.0-rc-2"
+(defproject com.walmartlabs/lacinia-pedestal "0.7.0"
   :description "Pedestal infrastructure supporting Lacinia GraphQL"
   :url "https://github.com/walmartlabs/pedestal-lacinia"
   :license {:name "Apache Software License 2.0"

--- a/src/com/walmartlabs/lacinia/pedestal.clj
+++ b/src/com/walmartlabs/lacinia/pedestal.clj
@@ -19,7 +19,8 @@
     [com.walmartlabs.lacinia.executor :as executor]
     [com.walmartlabs.lacinia.constants :as constants]
     [io.pedestal.http.jetty.websockets :as ws]
-    [com.walmartlabs.lacinia.pedestal.subscriptions :as subscriptions]))
+    [com.walmartlabs.lacinia.pedestal.subscriptions :as subscriptions]
+    [clojure.spec.alpha :as s]))
 
 (def ^:private default-subscriptions-path "/graphql-ws")
 
@@ -306,8 +307,11 @@
   : If true, the query will execute asynchronously.
 
   :app-context
-  : The base application context provided to Lacinia when executing a query."
-  {:added "0.3.0"}
+  : The base application context provided to Lacinia when executing a query.
+
+  This function will be removed in 0.8.0.  Use [[default-interceptors]] instead."
+  {:added "0.3.0"
+   :deprecated "0.7.0"}
   [compiled-schema options]
   (let [query-parser (query-parser-interceptor compiled-schema)
         inject-app-context (inject-app-context-interceptor (:app-context options))
@@ -325,23 +329,71 @@
         (assoc ::query-executor
                (ordered-after executor [::inject-app-context ::disallow-subscriptions])))))
 
+(defn default-interceptors
+  "Returns the default set of GraphQL interceptors, as a seq:
+
+    * ::json-response [[json-response-interceptor]]
+    * ::graphql-data [[graphql-data-interceptor]]
+    * ::status-conversion [[status-conversion-interceptor]]
+    * ::missing-query [[missing-query-interceptor]]
+    * ::query-parser [[query-parser-interceptor]]
+    * ::disallow-subscriptions [[disallow-subscriptions-interceptor]]
+    * ::inject-app-context [[inject-app-context-interceptor]]
+    * ::query-executor [[query-executor-handler]] or [[async-query-executor-handler]]
+
+  `compiled-schema` may be the actual compiled schema, or a no-arguments function that returns the compiled schema.
+
+  Often, this list of interceptors is augemented by calls to [[inject]].
+
+  Options:
+
+  :async (default false)
+  : If true, the query will execute asynchronously (return a core.async channel).
+
+  :app-context
+  : The base application context provided to Lacinia when executing a query.
+  "
+  {:added "0.7.0"}
+  [compiled-schema options]
+  (-> (graphql-interceptors compiled-schema options)
+      interceptors/order-by-dependency))
+
+(defn routes-from-interceptors
+  "Returns a set of route vectors from a primary seq of interceptors.
+  This returns a two element set, one for GET (using the seq as is),
+  and one for POST (prefixing with [[body-data-interceptor]].
+
+  Options:
+
+  :get-enabled (default true)
+  : If true, then a route for the GET method is included."
+  {:added "0.7.0"}
+  [route-path interceptors options]
+  (let [{:keys [get-enabled]
+         :or {get-enabled true}} options
+        post-interceptors (-> (cons body-data-interceptor interceptors)
+                              ;; Absolutely needs to be a vector, under penalty of
+                              ;; https://github.com/pedestal/pedestal/issues/308
+                              vec)]
+    (cond-> #{[route-path :post post-interceptors
+               :route-name ::graphql-post]}
+      get-enabled (conj [route-path :get interceptors
+                         :route-name ::graphql-get]))))
+
 (defn routes-from-interceptor-map
   "Returns a set of route vectors from a primary interceptor dependency map.
   This uses a standard rule for splicing in the POST support.
 
   This function is useful as an alternative to [[graphql-routes]] when the
-  default interceptor dependency map (from [[graphql-interceptors]]) is modified."
-  {:added "0.3.0"}
+  default interceptor dependency map (from [[graphql-interceptors]]) is modified.
+
+  This function will be removed in 0.8.0."
+  {:added "0.3.0"
+   :deprecated "0.7.0"}
   [route-path get-interceptor-map]
-  (let [post-interceptor-map (-> get-interceptor-map
-                                 (add body-data-interceptor ::json-response)
-                                 (update ::graphql-data ordered-after [::body-data]))]
-    #{[route-path :post
-       (interceptors/order-by-dependency post-interceptor-map)
-       :route-name ::graphql-post]
-      [route-path :get
-       (interceptors/order-by-dependency get-interceptor-map)
-       :route-name ::graphql-get]}))
+  (routes-from-interceptors route-path
+                            (interceptors/order-by-dependency get-interceptor-map)
+                            nil))
 
 (defn ^:private read-graphiql-html
   "Reads the graphiql.html resource, then injects new content into it, and ultimately returns a canned
@@ -371,8 +423,8 @@
   Returns a set of route vectors, compatible with
   `io.pedestal.http.route.definition.table/table-routes`.
 
-  Uses [[graphql-interceptors]] to define the base set of interceptors and
-  dependencies.  For the POST route, [[body-data-interceptor]] is spliced in.
+  Uses [[default-interceptors]] to define the base seq of interceptors.
+  For the POST route, [[body-data-interceptor]] is prepended.
 
   `compiled-schema` may be the actual compiled schema, or a no-arguments function
   that returns the compiled schema.
@@ -395,7 +447,8 @@
   : Passed back in requests from the IDE as the \"apikey\" header.
 
   :interceptors
-  : The map of interceptors to be passed to [[routes-from-interceptor-map]].
+  : A seq of interceptors, to be passed to [[routes-from-interceptors]].
+  : Alternately (deprected but supported), the map of interceptors to be passed to [[routes-from-interceptor-map]].
     If not provided, [[graphql-interceptors]] is invoked.
 
   :async (default: false)
@@ -414,7 +467,7 @@
               asset-path "/assets/graphiql"
               ide-path "/"}} options
         get-interceptor-map (or (:interceptors options)
-                                (graphql-interceptors compiled-schema options))
+                                (default-interceptors compiled-schema options))
 
         index-handler (when graphiql
                         (let [index-response (read-graphiql-html path asset-path options)]
@@ -426,8 +479,14 @@
                                                         {:root "graphiql"}))
         asset-head-handler #(-> %
                                 asset-get-handler
-                                (assoc :body nil))]
-    (cond-> (routes-from-interceptor-map path get-interceptor-map)
+                                (assoc :body nil))
+        ;; We're currently in transition; the interceptor dependency map is deprecated in 0.7.0,
+        ;; but still supported.  But a modern client may pass a seq of interceptors, not a dependency
+        ;; map.
+        routes (if (map? get-interceptor-map)
+                 (routes-from-interceptor-map path get-interceptor-map)
+                 (routes-from-interceptors path get-interceptor-map options))]
+    (cond-> routes
       graphiql (conj [ide-path :get index-handler :route-name ::graphiql-ide-index]
                      [asset-path' :get asset-get-handler :route-name ::graphiql-get-assets]
                      [asset-path' :head asset-head-handler :route-name ::graphiql-head-assets]))))
@@ -453,7 +512,7 @@
     that Pedestal 0.5.3 generates by default.
 
   :interceptors
-  : Map of interceptor names to interceptors, with dependencies.
+  : A seq of interceptors, or a dependency map of interceptor names to interceptors, with dependencies.
     If not provided, default is via [[graphql-interceptors]].
     Used to build the routes (via [[routes-from-interceptor-map]]).
 
@@ -479,8 +538,9 @@
   : Passed back in requests from the IDE as the \"apikey\" header.
 
   :interceptors
-  : The map of interceptors to be passed to [[routes-from-interceptor-map]].
-    If not provided, [[graphql-interceptors]] is invoked.
+  : A seq of interceptors to be used in GraphQL routes; passed to [[routes-from-interceptors]].
+  : Alternately (deprecated, but supported) the map of interceptors to be passed to [[routes-from-interceptor-map]].
+    If not provided, [[default-interceptors]] is invoked.
 
   :async (default: false)
   : If true, the query will execute asynchronously; the handler will return a clojure.core.async
@@ -499,7 +559,7 @@
   :env (default: :dev)
   : Environment being started.
 
-  See further notes in [[graphql-routes]] and [[graphql-interceptors]]."
+  See further notes in [[graphql-routes]] and [[default-interceptors]]."
   {:added "0.5.0"}
   [compiled-schema options]
   (let [{:keys [graphiql subscriptions port env subscriptions-path]
@@ -533,7 +593,56 @@
   "This function has been deprecated in favor of [[service-map]], but is being maintained for
   compatibility.
 
-  This simply invokes [[service-map]] and passes the resulting map through `io.pedestal.http/create-server`."
+  This simply invokes [[service-map]] and passes the resulting map through `io.pedestal.http/create-server`.
+
+  To be removed in 0.8.0."
   {:deprecated "0.5.0"}
   [compiled-schema options]
   (http/create-server (service-map compiled-schema options)))
+
+(defn inject
+  "Locates the named interceptor in the list of interceptors and adds (or replaces)
+  the new interceptor to the list.
+
+  relative-position may be :before, :after, or :replace.
+
+  The named interceptor must exist, or an exception is thrown."
+  {:added "0.7.0"}
+  [interceptors new-interceptor relative-position interceptor-name]
+  (let [*found? (volatile! false)
+        final-result (reduce (fn [result interceptor]
+                               (if-not (= interceptor-name (:name interceptor))
+                                 (conj result interceptor)
+                                 (do
+                                   (vreset! *found? true)
+                                   (case relative-position
+                                     :before
+                                     (conj result new-interceptor interceptor)
+
+                                     :after
+                                     (conj result interceptor new-interceptor)
+
+                                     :replace
+                                     (conj result new-interceptor)))))
+                             []
+                             interceptors)]
+    (when-not @*found?
+      (throw (ex-info "Could not find existing interceptor."
+                      {:interceptors interceptors
+                       :new-interceptor new-interceptor
+                       :relative-position relative-position
+                       :interceptor-name interceptor-name})))
+
+    final-result))
+
+(s/def ::interceptor (s/keys :req-un [::name]))
+(s/def ::interceptors (s/coll-of ::interceptor))
+;; The name of an interceptor; typically this is namespaced, but that is not a requirement.
+(s/def ::name keyword?)
+
+(s/fdef inject
+        :ret ::interceptors
+        :args (s/cat :interceptors ::interceptors
+                     :new-interceptor ::interceptor
+                     :relative-position #{:before :after :replace}
+                     :interceptor-name keyword?))

--- a/src/com/walmartlabs/lacinia/pedestal/interceptors.clj
+++ b/src/com/walmartlabs/lacinia/pedestal/interceptors.clj
@@ -1,6 +1,9 @@
 (ns com.walmartlabs.lacinia.pedestal.interceptors
-  "Utilities for building interceptor chains that are ordered based on dependencies."
-  {:added "0.3.0"}
+  "Utilities for building interceptor chains that are ordered based on dependencies.
+
+  This namespace has been deprecated; the single function [[inject]] is easier to use."
+  {:added "0.3.0"
+   :deprecated "0.7.0"}
   (:require
     [com.stuartsierra.dependency :as d]))
 


### PR DESCRIPTION
In the process of upgrading our internal applications to lacina-pedestal 0.6.0, I found the dependency-based approach for interceptors to be over-engineered and confusing.

Generally, I've found that you simply add a  new interceptor before or after another interceptor, starting from the known and expected ordering.

In practice, the dependency ordering logic got in the way, leading to fragile and confusing code to get the desired new interceptor into the right position.

So mea culpa; this PR is about deprecating that for a release, and switching the logic around so that the normal path is to operate on a vector (or seq) of interceptors.
The new inject function is used to add new interceptors to the vector with a position relative to an existing interceptor (either immediately before or immediately after, or actually replacing the
interceptor).

There's also some temporary logic that allows either a dependency map (0.6.0 code) or a interceptor vector (0.7.0 code) to work.

I doubt too many folks outside of Walmart used the lacinia.pedestal.interceptors namespace, but 0.7.0 will represent a chance to shift to this simpler model.