### PR TITLE
Replace API key support with more flexible IDE headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.7.0 -- UNRELEASED
+
+The :api-key option has been removed, replaced with the :ide-headers option.
+This is a more general approach that supports multiple headers with arbitrary names.
+
 ## 0.6.0 -- UNRELEASED
 
 It is now possible to configure the paths used to access the GraphQL endpoint and

--- a/dev-resources/demo.clj
+++ b/dev-resources/demo.clj
@@ -41,6 +41,7 @@
                    (lp/service-map {:graphiql true
                                     :path "/"
                                     :ide-path "/ui"
+                                    :ide-headers {"apikey" "mean mister mustard"}
                                     :subscriptions true
                                     :subscriptions-path "/ws"})
                    http/create-server

--- a/dev-resources/demo.clj
+++ b/dev-resources/demo.clj
@@ -61,3 +61,8 @@
   []
   (alter-var-root #'server stop-server)
   :stopped)
+
+(comment
+  (start)
+  (stop)
+  )

--- a/resources/com/walmartlabs/lacinia/pedestal/graphiql.html
+++ b/resources/com/walmartlabs/lacinia/pedestal/graphiql.html
@@ -89,7 +89,7 @@
           method: 'post',
           headers: {
             'Content-Type': 'application/json',
-            'apikey': '{{apikey}}'
+            '{{apikey-header}}': '{{apikey}}'
           },
           body: JSON.stringify({ query: graphQLParams.query,
                                  variables: graphQLParams.variables })

--- a/resources/com/walmartlabs/lacinia/pedestal/graphiql.html
+++ b/resources/com/walmartlabs/lacinia/pedestal/graphiql.html
@@ -87,10 +87,7 @@
       function graphQLFetcher(graphQLParams) {
         return fetch(window.location.origin + '{{path}}', {
           method: 'post',
-          headers: {
-            'Content-Type': 'application/json',
-            '{{apikey-header}}': '{{apikey}}'
-          },
+          headers: {{request-headers}},
           body: JSON.stringify({ query: graphQLParams.query,
                                  variables: graphQLParams.variables })
         }).then(function (response) {


### PR DESCRIPTION
This entirely removes the :api-key option, and replaces it with the new, more general, :ide-headers options.

It also exposes a new function for building and returning the GraphiQL IDE as a Ring response, needed when building customized access to the IDE (for example, to ensure an API key is in the header).