### PR TITLE
Merge the existing request data with that generated by previous interceptors / init-context fn

### DIFF
--- a/src/com/walmartlabs/lacinia/pedestal/subscriptions.clj
+++ b/src/com/walmartlabs/lacinia/pedestal/subscriptions.clj
@@ -76,7 +76,7 @@
           (>! cleanup-ch id))))
 
     ;; Execute the chain, for side-effects.
-    (chain/execute (assoc context :request request))
+    (chain/execute (update context :request merge request))
 
     ;; Return a shutdown channel that the CSP can close to shutdown the subscription
     shutdown-ch))

--- a/test/com/walmartlabs/lacinia/pedestal/subscription_interceptors_test.clj
+++ b/test/com/walmartlabs/lacinia/pedestal/subscription_interceptors_test.clj
@@ -31,7 +31,7 @@
   (interceptor
    {:name ::user-agent
     :enter (fn [context]
-             (reset! *user-agent (:user-agent context))
+             (reset! *user-agent (get-in context [:request :user-agent]))
              context)}))
 
 (defn ^:private options-builder
@@ -49,7 +49,7 @@
    (fn [ctx ^ServletUpgradeRequest req resp]
      (reset! *invoke-count 0)
      (reset! *user-agent nil)
-     (assoc ctx :user-agent (.getHeader (.getHttpServletRequest req) "User-Agent")))})
+     (assoc-in ctx [:request :user-agent] (.getHeader (.getHttpServletRequest req) "User-Agent")))})
 
 (use-fixtures :once (test-server-fixture {:subscriptions true
                                           :keep-alive-ms 200}


### PR DESCRIPTION
Hello,

This is related to previous PR #41 and allows the `init-context` function (and indeed any other interceptors) to set data in the `:request` map in the context without it being wiped out by lacinia.

This enables re-use of common pedestal interceptors which do things with the `:request` data.

Thanks for all your work on Lacinia!