### PR TITLE
Subscriptions: switch to sliding buffer, avoid too many puts, last value wins

### DIFF
--- a/docs/subscriptions.rst
+++ b/docs/subscriptions.rst
@@ -84,3 +84,17 @@ Subscription requests are not allowed in ``/graphql``.
   the server to signal to the client that the subscription has completed.
 
   The Apollo project also provides `clients in several languages <https://github.com/apollographql>`_.
+
+Resolution
+----------
+
+When a streamer invokes its callback, the value passed as an argument will either:
+
+* Be sent down the websocket connection to the client when there are no resolvers for the subscription root
+
+* Be passed as the "parent" value into the resolver specified for the subscription root
+
+Both cases occur asynchronously; the callback function returns immediately while further resolution of the graph occurs on another thread.
+If the callback is called again before the previous query has been resolved it will be queued in a LIFO buffer of 1; that is to say,
+if your graph is updating faster than it can be resolved then intermediate values will be dropped and the most recent value will be
+sent to the client.

--- a/src/com/walmartlabs/lacinia/pedestal/subscriptions.clj
+++ b/src/com/walmartlabs/lacinia/pedestal/subscriptions.clj
@@ -288,7 +288,7 @@
 
 (defn ^:private execute-subscription
   [context parsed-query]
-  (let [source-stream-ch (chan 1)
+  (let [source-stream-ch (chan (async/sliding-buffer 1))
         {:keys [id shutdown-ch response-data-ch]} (:request context)
         source-stream (fn [value]
                         (if (some? value)

--- a/src/com/walmartlabs/lacinia/pedestal/subscriptions.clj
+++ b/src/com/walmartlabs/lacinia/pedestal/subscriptions.clj
@@ -323,7 +323,8 @@
                                                :id id
                                                :payload response})))
                   ;; Don't execute the query in a limited go block thread
-                 thread)
+                 thread
+                 async/<!)
              (recur))
            (do
               ;; The streamer has signalled that it has exhausted the subscription.


### PR DESCRIPTION
Hi,

I'd like to get your opinion on this change. Background is that some queries can be very expensive, and the streamer may invoke the `source-stream` function faster than the query can be completed. This results in a build-up of pending puts on this channel which can eventually exceed 1024 and an exception is thrown.

Throttling on the streamer is of course possible but it is blind - you can debounce the `source-stream` function but you still can't know how long the query took to execute, and the function may easily be invoked again before the previous query has been completed.

This change prevents the pending puts from building up by adopting a last-one-wins attitude. It assumes that the client is not going to be interested in intermediate responses when there are newer ones just about to be delivered. This seems reasonable to me but you may think differently.

Further work could allow the size of the sliding buffer to be configured, or the addition of a synchronous version of `source-stream` which would only complete when the query had been completed, or some other mechanism to feed back the completion of the query to the streamer.

I haven't looked too closely at how the change introduced here could be explicitly tested, but it does pass all the existing tests.

Thanks