### PR TITLE
Properly handle interceptor seq

### DIFF
--- a/src/com/walmartlabs/lacinia/pedestal.clj
+++ b/src/com/walmartlabs/lacinia/pedestal.clj
@@ -488,9 +488,14 @@
          :or {path default-path
               asset-path default-asset-path
               ide-path "/"}} options
-        get-interceptor-map (or (:interceptors options)
-                                (graphql-interceptors compiled-schema options))
-        base-routes (routes-from-interceptor-map path get-interceptor-map)]
+        ;; In 0.7.0 interceptors may be either a map (old style) or a seq (new style).
+        ;; In 0.8.0, support for maps goes away and we delete a bunch of related functions
+        interceptors (or (:interceptors options)
+                         ;; Change to default-interceptors in 0.8.0:
+                         (graphql-interceptors compiled-schema options))
+        base-routes (if (map? interceptors)
+                      (routes-from-interceptor-map path interceptors)
+                      (routes-from-interceptors path interceptors options))]
     (if-not graphiql
       base-routes
       (let [index-handler (let [index-response (graphiql-ide-response options)]

--- a/test/com/walmartlabs/lacinia/pedestal_test.clj
+++ b/test/com/walmartlabs/lacinia/pedestal_test.clj
@@ -10,7 +10,11 @@
   (:import (clojure.lang ExceptionInfo)))
 
 
-(use-fixtures :once (test-server-fixture {:graphiql true}))
+(use-fixtures :once (test-server-fixture {:graphiql true}
+                                         (fn [schema]
+                                           ;; Force things to work as they will in 0.8.0,
+                                           ;; where the interceptors are a seq (not a map).
+                                           {:interceptors (lp/default-interceptors schema nil)})))
 
 (deftest simple-get-query
   (let [response (send-request "{ echo(value: \"hello\") { value method }}")]


### PR DESCRIPTION
The logic for generating GraphQL routes from a compiled schema was not quite right when the :interceptor option was  a seq (the new approach) and not a map (the old and deprecated approach), which caused the routes to be ordered incorrectly