### PR TITLE
Ignore duplicate subscriptions

### DIFF
--- a/src/com/walmartlabs/lacinia/pedestal/subscriptions.clj
+++ b/src/com/walmartlabs/lacinia/pedestal/subscriptions.clj
@@ -120,9 +120,11 @@
                 ;; TODO: Track state, don't allow start, etc. until after connection_init
 
                "start"
-               (do
-                 (log/debug :event ::start :id id)
-                 (recur (assoc subs id (execute-query-interceptors id payload response-data-ch cleanup-ch context))))
+               (if (contains? subs id)
+                 (do (log/debug :event ::ignoring-duplicate :id id)
+                     (recur subs))
+                 (do (log/debug :event ::start :id id)
+                     (recur (assoc subs id (execute-query-interceptors id payload response-data-ch cleanup-ch context)))))
 
                "stop"
                (do


### PR DESCRIPTION
Hi,

I originally thought that deduplication of subscriptions (two `start` messages with the same id) could or should be the responsibility of the application code. I implemented it in my own code and tried it out, but I observed that although I could avoid launching a new streamer thread, the original streamer thread never got cleaned up.

This is because the `(assoc subs id ...)` was running before the subscription interceptors so it was already too late by the time it hit my deduplication code - the cleanup function to be run on `stop` had been replaced and there was no handle for the original streamer cleanup function anymore.

This change detects duplicates and ignores them, ensuring that any streamer threads launched by this loop will also be cleaned up by this loop when the subscription is stopped.

I think this is valid behaviour because any new listeners created on the client side for this id will be satisfied by the existing streamer which will still be generating messages for it.

Please let me know if you have any questions,
Oliver