### PR TITLE
Attach connection init payload to streamer context

### DIFF
--- a/dev-resources/com/walmartlabs/lacinia/test_utils.clj
+++ b/dev-resources/com/walmartlabs/lacinia/test_utils.clj
@@ -14,8 +14,11 @@
     [io.pedestal.log :as log]
     [cheshire.core :as cheshire]))
 
+(def *echo-context (atom nil))
+
 (defn ^:private resolve-echo
   [context args _]
+  (reset! *echo-context context)
   (let [{:keys [value error]} args
         error-map (when error
                     {:message "Forced error."

--- a/dev-resources/com/walmartlabs/lacinia/test_utils.clj
+++ b/dev-resources/com/walmartlabs/lacinia/test_utils.clj
@@ -26,10 +26,12 @@
 
 (def *ping-subscribes (atom 0))
 (def *ping-cleanups (atom 0))
+(def *ping-context (atom nil))
 
 (defn ^:private stream-ping
   [context args source-stream]
   (swap! *ping-subscribes inc)
+  (reset! *ping-context context)
   (let [{:keys [message count]} args
         runnable ^Runnable (fn []
                              (dotimes [i count]
@@ -140,8 +142,12 @@
               (cheshire/generate-string data)))
 
 (defn send-init
-  []
-  (send-data {:type :connection_init}))
+  ([]
+   (send-init nil))
+  ([payload]
+   (send-data {:type :connection_init
+               :payload payload})))
+
 
 (defn <message!!
   ([]

--- a/src/com/walmartlabs/lacinia/pedestal/subscriptions.clj
+++ b/src/com/walmartlabs/lacinia/pedestal/subscriptions.clj
@@ -282,8 +282,9 @@
   (let [ch (chan 1)]
     (-> context
         (get-in [:request :lacinia-app-context])
-        (assoc :connection-params (:connection-params context))
-        (assoc constants/parsed-query-key parsed-query)
+        (assoc
+          :connection-params (:connection-params context)
+          constants/parsed-query-key parsed-query)
         executor/execute-query
         (resolve/on-deliver! (fn [response]
                                (put! ch (assoc context :response response))))
@@ -301,8 +302,9 @@
                           (close! source-stream-ch)))
         app-context (-> context
                         (get-in [:request :lacinia-app-context])
-                        (assoc :connection-params (:connection-params context))
-                        (assoc constants/parsed-query-key parsed-query))
+                        (assoc
+                          :connection-params (:connection-params context)
+                          constants/parsed-query-key parsed-query))
         cleanup-fn (executor/invoke-streamer app-context source-stream)]
     (go-loop []
       (alt!

--- a/src/com/walmartlabs/lacinia/pedestal/subscriptions.clj
+++ b/src/com/walmartlabs/lacinia/pedestal/subscriptions.clj
@@ -88,20 +88,19 @@
     ;; Keep track of subscriptions by (client-supplied) unique id.
     ;; The value is a shutdown channel that, when closed, triggers
     ;; a cleanup of the subscription.
-    (go-loop [subs {}
-              connection-payload nil]
+    (go-loop [connection-state {:subs {} :connection-payload nil}]
       (alt!
         cleanup-ch
         ([id]
          (log/debug :event ::cleanup-ch :id id)
-         (recur (dissoc subs id) connection-payload))
+         (recur (update connection-state :subs dissoc id)))
 
         ;; TODO: Maybe only after connection_init?
         (async/timeout keep-alive-ms)
         (do
           (log/debug :event ::timeout)
           (>! response-data-ch {:type :ka})
-          (recur subs connection-payload))
+          (recur connection-state))
 
         ws-data-ch
         ([data]
@@ -110,36 +109,38 @@
             ;; shutdown and cleanup.
            (do
              (log/debug :event ::client-close)
-             (run! close! (vals subs)))
+             (run! close! (-> connection-state :subs vals)))
             ;; Otherwise it's a message from the client to be acted upon.
            (let [{:keys [id payload type]} data]
              (case type
                "connection_init"
                (when (>! response-data-ch {:type :connection_ack})
-                 (recur subs payload))
+                 (recur (assoc connection-state :connection-payload payload)))
 
                 ;; TODO: Track state, don't allow start, etc. until after connection_init
 
                "start"
-               (if (contains? subs id)
-                 (do (log/debug :event ::ignoring-duplicate :id id)
-                     (recur subs connection-payload))
-                 (let [merged-context (merge context {:connection-params connection-payload})]
+               (if (contains? (:subs connection-state) id)
+                 (do
+                   (log/debug :event ::ignoring-duplicate :id id)
+                   (recur connection-state))
+                 (do
                    (log/debug :event ::start :id id)
-                   (recur (assoc subs id (execute-query-interceptors id payload response-data-ch cleanup-ch merged-context))
-                          connection-payload)))
+                   (let [merged-context (assoc context :connection-params (:connection-payload connection-state))
+                         sub-shutdown-ch (execute-query-interceptors id payload response-data-ch cleanup-ch merged-context)]
+                     (recur (assoc-in connection-state [:subs id] sub-shutdown-ch)))))
 
                "stop"
                (do
                  (log/debug :event ::stop :id id)
-                 (when-some [sub-shutdown-ch (get subs id)]
+                 (when-some [sub-shutdown-ch (get-in connection-state [:subs id])]
                    (close! sub-shutdown-ch))
-                 (recur subs connection-payload))
+                 (recur connection-state))
 
                "connection_terminate"
                (do
                  (log/debug :event ::terminate)
-                 (run! close! (vals subs))
+                 (run! close! (-> connection-state :subs vals))
                   ;; This shuts down the connection entirely.
                  (close! response-data-ch))
 
@@ -150,7 +151,7 @@
                                 id (assoc :id id))]
                  (log/debug :event ::unknown-type :type type)
                  (>! response-data-ch response)
-                 (recur subs connection-payload))))))))))
+                 (recur connection-state))))))))))
 
 ;; We try to keep the interceptors here and in the main namespace as similar as possible, but
 ;; there are distinctions that can't be readily smoothed over.

--- a/src/com/walmartlabs/lacinia/pedestal/subscriptions.clj
+++ b/src/com/walmartlabs/lacinia/pedestal/subscriptions.clj
@@ -94,7 +94,7 @@
         cleanup-ch
         ([id]
          (log/debug :event ::cleanup-ch :id id)
-         (recur (dissoc subs id) {}))
+         (recur (dissoc subs id) connection-payload))
 
         ;; TODO: Maybe only after connection_init?
         (async/timeout keep-alive-ms)

--- a/src/com/walmartlabs/lacinia/pedestal/subscriptions.clj
+++ b/src/com/walmartlabs/lacinia/pedestal/subscriptions.clj
@@ -281,8 +281,8 @@
   [context parsed-query]
   (let [ch (chan 1)]
     (-> context
-        :request
-        :lacinia-app-context
+        (get-in [:request :lacinia-app-context])
+        (assoc :connection-params (:connection-params context))
         (assoc constants/parsed-query-key parsed-query)
         executor/execute-query
         (resolve/on-deliver! (fn [response]
@@ -301,7 +301,7 @@
                           (close! source-stream-ch)))
         app-context (-> context
                         (get-in [:request :lacinia-app-context])
-                        (merge {:connection-params (:connection-params context)})
+                        (assoc :connection-params (:connection-params context))
                         (assoc constants/parsed-query-key parsed-query))
         cleanup-fn (executor/invoke-streamer app-context source-stream)]
     (go-loop []

--- a/src/com/walmartlabs/lacinia/pedestal/subscriptions.clj
+++ b/src/com/walmartlabs/lacinia/pedestal/subscriptions.clj
@@ -88,7 +88,7 @@
     ;; Keep track of subscriptions by (client-supplied) unique id.
     ;; The value is a shutdown channel that, when closed, triggers
     ;; a cleanup of the subscription.
-    (go-loop [connection-state {:subs {} :connection-payload nil}]
+    (go-loop [connection-state {:subs {} :connection-params nil}]
       (alt!
         cleanup-ch
         ([id]
@@ -115,7 +115,7 @@
              (case type
                "connection_init"
                (when (>! response-data-ch {:type :connection_ack})
-                 (recur (assoc connection-state :connection-payload payload)))
+                 (recur (assoc connection-state :connection-params payload)))
 
                 ;; TODO: Track state, don't allow start, etc. until after connection_init
 
@@ -126,7 +126,7 @@
                    (recur connection-state))
                  (do
                    (log/debug :event ::start :id id)
-                   (let [merged-context (assoc context :connection-params (:connection-payload connection-state))
+                   (let [merged-context (assoc context :connection-params (:connection-params connection-state))
                          sub-shutdown-ch (execute-query-interceptors id payload response-data-ch cleanup-ch merged-context)]
                      (recur (assoc-in connection-state [:subs id] sub-shutdown-ch)))))
 


### PR DESCRIPTION
Based on this initial proposal: https://github.com/walmartlabs/lacinia-pedestal/pull/26

I mainly applied code review's feedback, the only difference with original PR is that I propose we don't merge `context` with the given payload, but to attach the payload on `:connection-params` key instead.