### PR TITLE
Set no-referrer header on queries

### DIFF
--- a/resources/com/walmartlabs/lacinia/pedestal/graphiql.html
+++ b/resources/com/walmartlabs/lacinia/pedestal/graphiql.html
@@ -88,6 +88,7 @@
         return fetch(window.location.origin + '{{path}}', {
           method: 'post',
           headers: {{request-headers}},
+          referrer: "no-referrer",
           credentials: 'include',
           body: JSON.stringify(graphQLParams)
         }).then(function (response) {


### PR DESCRIPTION
Large queries fail with a "Request Header Fields Too Large" error. 
Setting this header omits including the encoded graphql query in the referrer header.