### PR TITLE
Make use of clojure-future-spec backfill functions to ensure Clojure 1.8 compatibility

### DIFF
--- a/src/com/walmartlabs/lacinia/pedestal.clj
+++ b/src/com/walmartlabs/lacinia/pedestal.clj
@@ -34,6 +34,9 @@
     [clojure.spec.alpha :as s]
     [com.walmartlabs.lacinia.pedestal.spec :as spec]))
 
+(when (-> *clojure-version* :minor (< 9))
+  (require '[clojure.future :refer [boolean? pos-int?]]))
+
 (def ^:private default-path "/graphql")
 
 (def ^:private default-asset-path "/assets/graphiql")

--- a/src/com/walmartlabs/lacinia/pedestal/spec.clj
+++ b/src/com/walmartlabs/lacinia/pedestal/spec.clj
@@ -24,6 +24,9 @@
     (com.walmartlabs.lacinia.schema CompiledSchema)
     (io.pedestal.interceptor Interceptor)))
 
+(when (-> *clojure-version* :minor (< 9))
+  (require '[clojure.future :refer [pos-int?]]))
+
 (s/def ::compiled-schema (s/or :direct #(instance? CompiledSchema %)
                                :indirect fn?))
 

--- a/src/com/walmartlabs/lacinia/pedestal/subscriptions.clj
+++ b/src/com/walmartlabs/lacinia/pedestal/subscriptions.clj
@@ -38,6 +38,9 @@
   (:import
     (org.eclipse.jetty.websocket.api UpgradeResponse)))
 
+(when (-> *clojure-version* :minor (< 9))
+  (require '[clojure.future :refer [pos-int?]]))
+
 (defn ^:private xform-channel
   [input-ch output-ch xf]
   (go-loop []


### PR DESCRIPTION
A couple of 1.9-only functions (boolean?, pos-int?) snuck in; change the code to get them from clojure-future on 1.8.

Fixes #81 