### PR TITLE
Relax specs to enable passing zero as HTTP port

### DIFF
--- a/src/com/walmartlabs/lacinia/pedestal.clj
+++ b/src/com/walmartlabs/lacinia/pedestal.clj
@@ -644,6 +644,6 @@
 (s/def ::ide-headers map?)
 (s/def ::async boolean?)
 (s/def ::subscriptions-path ::path)
-(s/def ::port pos-int?)
+(s/def ::port nat-int?)
 (s/def ::env keyword?)
 


### PR DESCRIPTION
Previously, Lacinia would error with spec instrumentation on when attempting to use port zero to have the OS allocate an available port number.

Getting a randomly assigned port is useful when you want to parallelize your test suite.