### PR TITLE
Fix typo in docstring

### DIFF
--- a/src/com/walmartlabs/lacinia/pedestal.clj
+++ b/src/com/walmartlabs/lacinia/pedestal.clj
@@ -264,7 +264,7 @@
 
 (def ^{:added "0.10.0"} prepare-query-interceptor
   "Prepares (with query variables) and validates the query, previously parsed
-  by [[query-parsed-interceptor]].
+  by [[query-parser-interceptor]].
 
   In earlier releases of lacinia-pedestal, this logic was combined with [[query-parser-interceptor]]."
   (interceptor


### PR DESCRIPTION
I've found a typo in the docstring of `com.walmartlabs.lacinia.pedestal/prepare-query-interceptor`.

cf. https://walmartlabs.github.io/apidocs/lacinia-pedestal/com.walmartlabs.lacinia.pedestal.html#var-prepare-query-interceptor