### PR TITLE
Add new pedestal2 namespace to simplify complex routing

### DIFF
--- a/.joker
+++ b/.joker
@@ -1,0 +1,2 @@
+{:known-macros
+    [com.walmartlabs.lacinia.internal-utils/cond-let]}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 New `com.walmartlabs.lacinia.pedestal2` namespace de-complects
 configuration.
+The new namespace provides the same basic building blocks, but (beyond a very simple
+`default-service` function) encourages you to assemble the system from the basics
+as you see fit; the prior approach had become overrun with confusing options.
+
+These changes make it far easier to support multiple schemas, or versions of schemas,
+on different endpoints within the same server.
+
+[Closed Issues](https://github.com/walmartlabs/lacinia-pedestal/milestone/13?closed=1)
 
 ## 0.13.0 -- 13 Feb 2020
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.14.0 -- UNRELEASED
+
+New `com.walmartlabs.lacinia.pedestal2` namespace de-complects
+configuration.
+
 ## 0.13.0 -- 13 Feb 2020
 
 The `inject-app-context-interceptor` function has moved to the new

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,4 @@
-## 0.13.0 -- UNRELEASED
-
+## 0.13.0 -- 13 Feb 2020
 
 The `inject-app-context-interceptor` function has moved to the new
 `com.walmartlabs.lacinia.pedestal.interceptors` namespace. This merges

--- a/README.md
+++ b/README.md
@@ -17,25 +17,28 @@ as [Apollo GraphQL](https://github.com/apollographql/subscriptions-transport-ws)
 ## Usage
 
 For a basic Pedestal server, simply supply a compiled Lacinia schema to
-the `com.walmartlabs.lacinia.pedestal/service-map` function to
+the `com.walmartlabs.lacinia.pedestal2/default-service` function to
 generate a service, then invoke `io.pedestal.http/create-server` and `/start`.
 
 ```clojure
 ;; This example is based off of the code generated from the template
-;;  `lein new pedestal-service graphql-demo`
+;;  `lein new pedestal-service graphql-demo`, 
 
 (ns graphql-demo.server
   (:require [io.pedestal.http :as http]
-            [com.walmartlabs.lacinia.pedestal :as lacinia]
+            [com.walmartlabs.lacinia.pedestal2 :as lp]
             [com.walmartlabs.lacinia.schema :as schema]))
 
-(def hello-schema (schema/compile
-                   {:queries {:hello
-                              ;; String is quoted here; in EDN the quotation is not required
-                              {:type 'String
-                               :resolve (constantly "world")}}}))
+(def hello-schema 
+(schema/compile
+  {:queries 
+    {:hello
+      ;; String is quoted here; in EDN the quotation is not required
+      {:type 'String
+       :resolve (constantly "world")}}}))
 
-(def service (lacinia/service-map hello-schema {:graphiql true}))
+;; Use default options:
+(def service (lp/default-service hello-schema nil))
 
 ;; This is an adapted service map, that can be started and stopped
 ;; From the REPL you can call server/start and server/stop on this service
@@ -48,23 +51,33 @@ generate a service, then invoke `io.pedestal.http/create-server` and `/start`.
   (http/start runnable-service))
 ```
 
-Lacinia will handle GET and POST requests at the `/graphql` endpoint.
+Lacinia will handle POST requests at the `/api` endpoint:
 
 ```
-$ curl localhost:8888/graphql -X POST -H "content-type: application/graphql" -d '{ hello }'
+$ curl localhost:8888/api -X POST -H "content-type: application/json" -d '{"query": "{ hello }"}'
 {"data":{"hello":"world"}}
 ```
+
+You can also access the GraphQL IDE at `http://localhost:8888/ide`.
 
 ## Development Mode
 
 When developing an application, it is desirable to be able to change the schema
 without restarting.
 Lacinia-Pedestal supports this: in the above example, the schema passed to
-`pedestal-service` could be a _function_ that returns the compiled schema.
+`default-service` could be a _function_ that returns the compiled schema.
 It could even be a Var containing the function that returns the compiled schema.
 
 In this way, the Pedestal stack continues to run, but each request rebuilds
 the compiled schema based on the latest code you've loaded into the REPL.
+
+## Beyond default-server
+
+`default-server` is intentionally limited, and exists only to help you get started.
+Once you start adding anything more complicated, such as authentication, or supporting
+multiple schemas (or schema versions) at different paths, 
+you will want to simply create your routes and servers in your own code,
+using the building-blocks provided by `com.walmartlabs.lacinia.pedestal2`.
 
 ### GraphiQL
 
@@ -73,7 +86,7 @@ version `0.12.0`.
 
 ## License
 
-Copyright © 2017 Walmart
+Copyright © 2017-2020 Walmart
 
 Distributed under the Apache Software License 2.0.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ generate a service, then invoke `io.pedestal.http/create-server` and `/start`.
 
 ```clojure
 ;; This example is based off of the code generated from the template
-;;  `lein new pedestal-service graphql-demo`, 
+;;  `lein new pedestal-service graphql-demo`
 
 (ns graphql-demo.server
   (:require [io.pedestal.http :as http]

--- a/dev-resources/logback.xml
+++ b/dev-resources/logback.xml
@@ -15,6 +15,7 @@
     <logger name="io.pedestal.interceptor" level="warn"/>
 
     <logger name="com.walmartlabs.lacinia" level="warn"/>
+    <logger name="com.walmartlabs.lacinia.test-utils" level="warn"/>
 
     <logger name="org.eclipse.jetty.websocket" level="warn"/>
     <logger name="clj-antlr.common" level="error"/>

--- a/project.clj
+++ b/project.clj
@@ -8,16 +8,16 @@
                  [com.fasterxml.jackson.core/jackson-core "2.10.2"]
                  [io.pedestal/pedestal.service "0.5.7"]
                  [io.pedestal/pedestal.jetty "0.5.7"]
-                 [org.clojure/data.json "0.2.7"]]
+                 [org.clojure/data.json "1.0.0"]]
   :profiles
   {:dev {:dependencies [[clj-http "2.3.0"]
                         [com.walmartlabs/test-reporting "0.1.0"]
                         [expound "0.8.4"]
-                        [stylefruits/gniazdo "1.1.2"
+                        [stylefruits/gniazdo "1.1.3"
                          :exclusions [org.eclipse.jetty.websocket/websocket-client]]
                         [io.aviso/logging "0.3.2"]]}}
   :jvm-opts ["-Xmx500m"]
-  :plugins [[lein-codox "0.10.3"]
+  :plugins [[lein-codox "0.10.7"]
             [test2junit "1.3.0"]
             [lein-shell "0.5.0"]]
   :shell {:dir "resources/graphiql"}

--- a/project.clj
+++ b/project.clj
@@ -1,10 +1,10 @@
-(defproject com.walmartlabs/lacinia-pedestal "0.13.0-rc-1"
+(defproject com.walmartlabs/lacinia-pedestal "0.13.0"
   :description "Pedestal infrastructure supporting Lacinia GraphQL"
   :url "https://github.com/walmartlabs/pedestal-lacinia"
   :license {:name "Apache Software License 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
   :dependencies [[org.clojure/clojure "1.10.1"]
-                 [com.walmartlabs/lacinia "0.36.0-rc-1"]
+                 [com.walmartlabs/lacinia "0.36.0"]
                  [com.fasterxml.jackson.core/jackson-core "2.10.2"]
                  [io.pedestal/pedestal.service "0.5.7"]
                  [io.pedestal/pedestal.jetty "0.5.7"]

--- a/resources/com/walmartlabs/lacinia/pedestal/graphiql.html
+++ b/resources/com/walmartlabs/lacinia/pedestal/graphiql.html
@@ -86,7 +86,7 @@
 
       // Defines a GraphQL fetcher using the fetch API.
       function graphQLFetcher(graphQLParams) {
-        return fetch(window.location.origin + '{{path}}', {
+        return fetch(window.location.origin + '{{api-path}}', {
           method: 'post',
           headers: {{request-headers}},
           referrer: "no-referrer",

--- a/resources/graphiql/package-lock.json
+++ b/resources/graphiql/package-lock.json
@@ -408,7 +408,7 @@
     },
     "node-fetch": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
+      "resolved": "http://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
       "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U="
     },
     "object-assign": {

--- a/src/com/walmartlabs/lacinia/pedestal.clj
+++ b/src/com/walmartlabs/lacinia/pedestal.clj
@@ -13,28 +13,20 @@
 ; limitations under the License.
 
 (ns com.walmartlabs.lacinia.pedestal
-  "Defines Pedestal interceptors and supporting code."
+  "Defines Pedestal interceptors and supporting code.
+
+  Many functions here were deprecated in 0.14.0, with replacements in the
+  [[com.walmartlabs.lacinia.pedestal2]] namespace."
   (:require
-    [clojure.core.async :refer [chan put!]]
     [cheshire.core :as cheshire]
     [io.pedestal.interceptor :refer [interceptor]]
     [clojure.string :as str]
-    [clojure.java.io :as io]
     [io.pedestal.http :as http]
     [ring.util.response :as response]
-    [com.walmartlabs.lacinia.resolve :as resolve]
-    [com.walmartlabs.lacinia.parser :as parser]
-    [com.walmartlabs.lacinia.util :as util]
-    [com.walmartlabs.lacinia.validator :as validator]
-    [com.walmartlabs.lacinia.executor :as executor]
-    [com.walmartlabs.lacinia.constants :as constants]
-    [com.walmartlabs.lacinia.internal-utils :refer [cond-let]]
-    [io.pedestal.http.jetty.websockets :as ws]
-    [com.walmartlabs.lacinia.pedestal.subscriptions :as subscriptions]
     [com.walmartlabs.lacinia.pedestal.interceptors :as interceptors]
     [clojure.spec.alpha :as s]
     [com.walmartlabs.lacinia.pedestal.spec :as spec]
-    [io.pedestal.log :as log]))
+    [com.walmartlabs.lacinia.pedestal.internal :as internal]))
 
 (when (-> *clojure-version* :minor (< 9))
   (require '[clojure.future :refer [boolean? pos-int?]]))
@@ -44,41 +36,6 @@
 (def ^:private default-asset-path "/assets/graphiql")
 
 (def ^:private default-subscriptions-path "/graphql-ws")
-
-(def ^:private parsed-query-key-path [:request :parsed-lacinia-query])
-
-(defn ^:private failure-response
-  "Generates a bad request Ring response."
-  ([body]
-   (failure-response 400 body))
-  ([status body]
-   {:status status
-    :headers {}
-    :body body}))
-
-(defn ^:private message-as-errors
-  [message]
-  {:errors [{:message message}]})
-
-(defn ^:no-doc parse-content-type
-  "Parse `s` as an RFC 2616 media type."
-  [s]
-  (if-let [[_ type _ _ raw-params] (re-matches #"\s*(([^/]+)/([^ ;]+))\s*(\s*;.*)?" (str s))]
-    {:content-type (keyword type)
-     :content-type-params
-     (->> (str/split (str raw-params) #"\s*;\s*")
-          (keep identity)
-          (remove str/blank?)
-          (map #(str/split % #"="))
-          (mapcat (fn [[k v]] [(keyword (str/lower-case k)) (str/trim v)]))
-          (apply hash-map))}))
-
-
-(defn ^:private content-type
-  "Gets the content-type of a request. (without encoding)"
-  [request]
-  (if-let [content-type (get-in request [:headers "content-type"])]
-    (:content-type (parse-content-type content-type))))
 
 (defn inject
   "Locates the named interceptor in the list of interceptors and adds (or replaces)
@@ -125,25 +82,25 @@
 (s/def ::name (s/nilable keyword?))
 
 (s/fdef inject
-  :ret ::interceptors
-  :args (s/cat :interceptors ::interceptors
-               :new-interceptor ::interceptor
-               :relative-position #{:before :after :replace}
-               :interceptor-name keyword?))
+        :ret ::interceptors
+        :args (s/cat :interceptors ::interceptors
+                     :new-interceptor ::interceptor
+                     :relative-position #{:before :after :replace}
+                     :interceptor-name keyword?))
 
 (defmulti extract-query
-  "Based on the content type of the query, adds up to three keys to the request:
+          "Based on the content type of the query, adds up to three keys to the request:
 
-  :graphql-query
-  : The query itself, as a string (parsing the query happens later).
+          :graphql-query
+          : The query itself, as a string (parsing the query happens later).
 
-  :graphql-vars
-  : A map of variables used when executing the query.
+          :graphql-vars
+          : A map of variables used when executing the query.
 
-  :graphql-operation-name
-  : The specific operation requested (for queries that define multiple named operations)."
-  (fn [request]
-    (content-type request)))
+          :graphql-operation-name
+          : The specific operation requested (for queries that define multiple named operations)."
+          (fn [request]
+            (internal/content-type request)))
 
 (defmethod extract-query :application/json [request]
   (let [body (cheshire/parse-string (:body request) true)
@@ -168,29 +125,28 @@
     (when query
       {:graphql-query query})))
 
-
-(def json-response-interceptor
+(def ^{:deprecated "0.14.0"} json-response-interceptor
   "An interceptor that sees if the response body is a map and, if so,
-  converts the map to JSON and sets the response Content-Type header."
+  converts the map to JSON and sets the response Content-Type header.
+
+  Deprecated: Use [[pedestal2/json-response-interceptor]] instead."
   (interceptor
     {:name ::json-response
-     :leave (fn [context]
-              (let [body (get-in context [:response :body])]
-                (if (map? body)
-                  (-> context
-                      (assoc-in [:response :headers "Content-Type"] "application/json")
-                      (update-in [:response :body] cheshire/generate-string))
-                  context)))}))
+     :leave internal/on-leave-json-response}))
 
-(def body-data-interceptor
-  "Converts the POSTed body from a input stream into a string."
+(def ^{:deprecated "0.14.0"} body-data-interceptor
+  "Converts the POSTed body from a input stream into a string.
+
+  Deprecated: Use [[pedetal2/body-data-interceptor]] instead."
   (interceptor
     {:name ::body-data
      :enter (fn [context]
               (update-in context [:request :body] slurp))}))
 
-(def graphql-data-interceptor
-  "Extracts the raw data (query and variables) from the request using [[extract-query]]."
+(def ^{:deprecated "0.14.0"} graphql-data-interceptor
+  "Extracts the raw data (query and variables) from the request using [[extract-query]].
+
+  Deprecated: Use [[pedestal2/graphql-data-interceptor]] instead."
   (interceptor
     {:name ::graphql-data
      :enter (fn [context]
@@ -198,10 +154,10 @@
                 (let [request (:request context)
                       q (extract-query request)]
                   (assoc context :request
-                         (merge request q)))
+                                 (merge request q)))
                 (catch Exception e
                   (assoc context :response
-                         (failure-response {:message (str "Invalid request: " (.getMessage e))})))))}))
+                                 (internal/failure-response {:message (str "Invalid request: " (.getMessage e))})))))}))
 
 (defn ^:private query-not-found-error
   [request]
@@ -212,37 +168,23 @@
                   (str/blank? body) "Request body is empty."
                   (::known-content-type request) "GraphQL query not supplied in request body."
                   :else "Request content type must be application/graphql or application/json.")]
-    (message-as-errors message)))
+    (internal/message-as-errors message)))
 
-(def missing-query-interceptor
+(def ^{:deprecated "0.14.0"} missing-query-interceptor
   "Rejects the request when there's no GraphQL query in the request map.
 
-   This must come after [[graphql-data-interceptor]], which is responsible for adding the query to the request map."
+   This must come after [[graphql-data-interceptor]], which is responsible for adding the query to the request map.
+
+   Deprecated: Use [[pedestal2/missing-query-interceptor]] instead."
   (interceptor
     {:name ::missing-query
      :enter (fn [context]
               (if (-> context :request :graphql-query str/blank?)
                 (assoc context :response
-                       (failure-response (query-not-found-error (:request context))))
+                               (internal/failure-response (query-not-found-error (:request context))))
                 context))}))
 
-(defn ^:private as-errors
-  [exception]
-  {:errors [(util/as-error-map exception)]})
-
-(defn ^:private parse-query-document
-  [context compiled-schema q operation-name]
-  (try
-    (let [actual-schema (if (map? compiled-schema)
-                          compiled-schema
-                          (compiled-schema))
-          parsed-query (parser/parse-query actual-schema q operation-name)]
-      (assoc-in context parsed-query-key-path parsed-query))
-    (catch Exception e
-      (assoc context :response
-             (failure-response (as-errors e))))))
-
-(defn query-parser-interceptor
+(defn ^{:deprecated "0.14.0"} query-parser-interceptor
   "Given an schema, returns an interceptor that parses the query.
 
    `compiled-schema` may be the actual compiled schema, or a no-arguments function
@@ -253,138 +195,68 @@
    Adds a new request key, :parsed-lacinia-query, containing the parsed query.
 
    Before execution, [[prepare-query-interceptor]] injects query variables and performs
-   validations."
+   validations.
+
+   Deprecated: Use [[pedestal2/query-parser-interceptor]] instead."
   [compiled-schema]
   (interceptor
     {:name ::query-parser
-     :enter (fn [context]
-              (let [{:keys [graphql-query graphql-operation-name]} (:request context)]
-                (parse-query-document context
-                                      compiled-schema
-                                      graphql-query
-                                      graphql-operation-name)))}))
+     :enter (internal/on-enter-query-parser compiled-schema)}))
 
-(def ^{:added "0.10.0"} prepare-query-interceptor
+(def ^{:added "0.10.0"
+       :deprecated "0.14.0"} prepare-query-interceptor
   "Prepares (with query variables) and validates the query, previously parsed
   by [[query-parser-interceptor]].
 
-  In earlier releases of lacinia-pedestal, this logic was combined with [[query-parser-interceptor]]."
+  In earlier releases of lacinia-pedestal, this logic was combined with [[query-parser-interceptor]].
+
+  Deprected: Use [[pedestal2/prepare-query-interceptor]] instead."
   (interceptor
     {:name ::prepare-query
-     :enter (fn [context]
-              (try
-                (let [{parsed-query :parsed-lacinia-query
-                       vars :graphql-vars} (:request context)
-                      prepared (parser/prepare-with-query-variables parsed-query vars)
-                      compiled-schema (get prepared constants/schema-key)
-                      errors (validator/validate compiled-schema prepared {})]
-                  (if (seq errors)
-                    (assoc context :response (failure-response {:errors errors}))
-                    (assoc-in context parsed-query-key-path prepared)))
-                (catch Exception e
-                  (assoc context :response
-                         (failure-response (as-errors e))))))}))
+     :enter internal/on-enter-prepare-query}))
 
-(defn ^:private remove-status
-  "Remove the :status key from the :extensions map; remove the :extensions key if that is now empty."
-  [error-map]
-  (if-not (contains? error-map :extensions)
-    error-map
-    (let [error-map' (update error-map :extensions dissoc :status)]
-      (if (-> error-map' :extensions seq)
-        error-map'
-        (dissoc error-map' :extensions)))))
-
-(def status-conversion-interceptor
+(def ^{:deprecated "0.14.0"} status-conversion-interceptor
   "Checks to see if any error map in the :errors key of the response
   contains a :status value (under it's :extensions key).
   If so, the maximum status value of such errors is found and used as the status of the overall response, and the
-  :status key is dissoc'ed from all errors."
+  :status key is dissoc'ed from all errors.
+
+  Deprecated: use [[pedestal2/status-conversion-interceptor]]."
   (interceptor
     {:name ::status-conversion
-     :leave (fn [context]
-              (let [response (:response context)
-                    errors (get-in response [:body :errors])
-                    statuses (keep #(-> % :extensions :status) errors)]
-                (if (seq statuses)
-                  (let [max-status (reduce max (:status response) statuses)]
-                    (-> context
-                        (assoc-in [:response :status] max-status)
-                        (assoc-in [:response :body :errors]
-                                  (map remove-status errors))))
-                  context)))}))
+     :leave internal/on-leave-status-conversion}))
 
-(defn ^:private apply-result-to-context
-  [context result]
-  ;; Lacinia changed the contract here is 0.36.0 (to support timeouts), the result
-  ;; maybe an exception thrown during initial processing of the query.
-  (if (instance? Throwable result)
-    (do
-      (log/error :event :execution-exception
-                 :ex result)
-      (assoc context :response (failure-response 500 (as-errors result))))
-    ;; When :data is missing, then a failure occurred during parsing or preparing
-    ;; the request, which indicates a bad request, rather than some failure
-    ;; during execution.
-    (let [status (if (contains? result :data)
-                   200
-                   400)
-          response {:status status
-                    :headers {}
-                    :body result}]
-      (assoc context :response response))))
-
-(defn ^:private execute-query
-  [context]
-  (let [request (:request context)
-        {q :parsed-lacinia-query
-         app-context :lacinia-app-context} request]
-    (executor/execute-query (assoc app-context
-                                   constants/parsed-query-key q))))
-
-(def query-executor-handler
+(def ^{:deprecated "0.14.0"} query-executor-handler
   "The handler at the end of interceptor chain, invokes Lacinia to
   execute the query and return the main response.
 
-  The handler adds the Ring request map as the :request key to the provided
-  app-context before executing the query.
-
   This comes after [[query-parser-interceptor]], [[inject-app-context-interceptor]],
-  and [[status-conversion-interceptor]] in the interceptor chain."
+  and [[status-conversion-interceptor]] in the interceptor chain.
+
+  Deprecated: Use [[pedestal2/query-executor-handler]] instead."
   (interceptor
     {:name ::query-executor
-     :enter (fn [context]
-              (let [resolver-result (execute-query context)
-                    *result (promise)]
-                (resolve/on-deliver! resolver-result
-                                     (fn [result]
-                                       (deliver *result result)))
-                (apply-result-to-context context @*result)))}))
+     :enter internal/on-enter-query-excecutor}))
 
-(def ^{:added "0.2.0"} async-query-executor-handler
+(def ^{:added "0.2.0"
+       :deprecated "0.14.0"} async-query-executor-handler
   "Async variant of [[query-executor-handler]] which returns a channel that conveys the
-  updated context."
+  updated context.
+
+  Deprecated: Use [[pedestal2/async-query-executor-handler]] instead."
   (interceptor
     {:name ::async-query-executor
-     :enter (fn [context]
-              (let [ch (chan 1)
-                    resolver-result (execute-query context)]
-                (resolve/on-deliver! resolver-result
-                                     (fn [result]
-                                       (->> result
-                                            (apply-result-to-context context)
-                                            (put! ch))))
-                ch))}))
+     :enter internal/on-enter-async-query-executor}))
 
-(def ^{:added "0.3.0"} disallow-subscriptions-interceptor
+(def ^{:added "0.3.0"
+       :deprecated "0.14.0"} disallow-subscriptions-interceptor
   "Handles requests for subscriptions.  Subscription requests must only be sent to the subscriptions web-socket, not the
-  general query endpoint, so any subscription request received in this pipeline is a bad request."
+  general query endpoint, so any subscription request received in this pipeline is a bad request.
+
+  Deprecated: Use [[pedestal2/disallow-subscriptions-interceptor]] instead."
   (interceptor
     {:name ::disallow-subscriptions
-     :enter (fn [context]
-              (if (-> context :request :parsed-lacinia-query parser/operations :type (= :subscription))
-                (assoc context :response (failure-response (message-as-errors "Subscription queries must be processed by the WebSockets endpoint.")))
-                context))}))
+     :enter internal/on-enter-disallow-subscriptions}))
 
 (defn default-interceptors
   "Returns the default set of GraphQL interceptors, as a seq:
@@ -403,8 +275,11 @@
 
   Often, this list of interceptors is augmented by calls to [[inject]].
 
-  Options are as defined by [[service-map]]."
-  {:added "0.7.0"}
+  Options are as defined by [[service-map]].
+
+  Deprecated: Use [[pedestal2/default-interceptors]] instead."
+  {:added "0.7.0"
+   :deprecated "0.14.0"}
   [compiled-schema options]
   [json-response-interceptor
    graphql-data-interceptor
@@ -426,8 +301,11 @@
   Options:
 
   :get-enabled (default true)
-  : If true, then a route for the GET method is included."
-  {:added "0.7.0"}
+  : If true, then a route for the GET method is included.
+
+  Deprecated with no replacement (build the route yourself)."
+  {:added "0.7.0"
+   :deprecated "0.14.0"}
   [_compiled-schema interceptors options]
   (let [{:keys [path get-enabled]
          :or {get-enabled true
@@ -435,8 +313,8 @@
         post-interceptors (into [body-data-interceptor] interceptors)]
     (cond-> #{[path :post post-interceptors
                :route-name ::graphql-post]}
-      get-enabled (conj [path :get interceptors
-                         :route-name ::graphql-get]))))
+            get-enabled (conj [path :get interceptors
+                               :route-name ::graphql-get]))))
 
 (defn graphiql-ide-response
   "Reads the graphiql.html resource, then injects new content into it, and ultimately returns a Ring
@@ -446,33 +324,19 @@
 
   Options are as specified in [[graphql-routes]].
 
-  Reads the template file, makes necessary substitutions, and returns a Ring response."
-  {:added "0.7.0"}
+  Reads the template file, makes necessary substitutions, and returns a Ring response.
+
+  Deprecated: Use [[pedestal2/graphiql-ide-handler]] instead."
+  {:added "0.7.0"
+   :deprecated "0.14.0"}
   [options]
   (let [{:keys [path asset-path subscriptions-path ide-headers ide-connection-params]
          :or {path default-path
               asset-path default-asset-path
-              subscriptions-path default-subscriptions-path}} options
-        ide-headers' (assoc ide-headers "Content-Type" "application/json")
-        replacements {:asset-path asset-path
-                      :path path
-                      :subscriptions-path subscriptions-path
-                      :initial-connection-params (cheshire/generate-string ide-connection-params)
-                      :request-headers (str "{"
-                                            (->> ide-headers'
-                                                 (map (fn [[k v]]
-                                                        (str \" (name k) "\": \"" (name v) \")))
-                                                 (str/join ", "))
-                                            "}")}]
-    (-> "com/walmartlabs/lacinia/pedestal/graphiql.html"
-        io/resource
-        slurp
-        (str/replace #"\{\{(.+?)}}" (fn [[_ key]]
-                                      (get replacements (keyword key) "--NO-MATCH--")))
-        response/response
-        (response/content-type "text/html"))))
+              subscriptions-path default-subscriptions-path}} options]
+    (internal/graphiql-response path subscriptions-path asset-path ide-headers ide-connection-params)))
 
-(defn graphql-routes
+(defn ^{:deprecated "0.14.0"} graphql-routes
   "Creates default routes for handling GET and POST requests and
   (optionally) the GraphiQL IDE.
 
@@ -489,7 +353,9 @@
 
   Asset paths use wildcard matching; you should be careful to ensure that the asset path does not
   overlap the paths for query request handling, the IDE, or subscriptions (or the asset handler will override the others
-  and deliver 404 responses)."
+  and deliver 404 responses).
+
+  Deprecated: Use the [[com.walmartlabs.lacinia.pedestal2]] namespace instead."
   [compiled-schema options]
   (let [{:keys [path ide-path asset-path graphiql]
          :or {path default-path
@@ -547,7 +413,7 @@
   : See [[listener-fn-factory]] for further options related to subscriptions.
 
   :path (default: \"/graphql\")
-  : Path at which GraphQL requests are services (distinct from the GraphQL IDE).
+  : Path at which GraphQL requests are serviced (distinct from the GraphQL IDE).
 
   :ide-path (default: \"/\")
   : Path from which the GraphiQL IDE, if enabled, can be loaded.
@@ -591,8 +457,11 @@
   :env (default: :dev)
   : Environment being started.
 
-  See further notes in [[graphql-routes]] and [[default-interceptors]]."
-  {:added "0.5.0"}
+  See further notes in [[graphql-routes]] and [[default-interceptors]].
+
+  Deprecated: Use [[default-service]] initially, then roll your own. Seriously."
+  {:added "0.5.0"
+   :deprecated "0.14.0"}
   [compiled-schema options]
   (let [{:keys [graphiql subscriptions port env subscriptions-path]
          :or {graphiql false
@@ -608,22 +477,15 @@
              ::http/type :jetty
              ::http/join? false}
 
-      subscriptions
-      (assoc-in [::http/container-options :context-configurator]
-                ;; The listener-fn is responsible for creating the listener; it is passed
-                ;; the request, response, and the ws-map. In sample code, the ws-map
-                ;; has callbacks such as :on-connect and :on-text, but in our scenario
-                ;; the callbacks are created by the listener-fn, so the value is nil.
-                #(ws/add-ws-endpoints % {subscriptions-path nil}
-                                      {:listener-fn
-                                       (subscriptions/listener-fn-factory compiled-schema options)}))
+            subscriptions
+            (internal/add-subscriptions-support compiled-schema subscriptions-path options)
 
-      graphiql
-      (assoc ::http/secure-headers nil))))
+            graphiql
+            (assoc ::http/secure-headers nil))))
 
 (s/fdef service-map
-  :args (s/cat :compiled-schema ::spec/compiled-schema
-               :options (s/nilable ::service-map-options)))
+        :args (s/cat :compiled-schema ::spec/compiled-schema
+                     :options (s/nilable ::service-map-options)))
 
 (s/def ::service-map-options (s/keys :opt-un [::graphiql
                                               ::routes

--- a/src/com/walmartlabs/lacinia/pedestal.clj
+++ b/src/com/walmartlabs/lacinia/pedestal.clj
@@ -357,9 +357,8 @@
 
   Deprecated: Use the [[com.walmartlabs.lacinia.pedestal2]] namespace instead."
   [compiled-schema options]
-  (let [{:keys [path ide-path asset-path graphiql]
-         :or {path default-path
-              asset-path default-asset-path
+  (let [{:keys [ide-path asset-path graphiql]
+         :or {asset-path default-asset-path
               ide-path "/"}} options
         interceptors (or (:interceptors options)
                          (default-interceptors compiled-schema options))

--- a/src/com/walmartlabs/lacinia/pedestal/internal.clj
+++ b/src/com/walmartlabs/lacinia/pedestal/internal.clj
@@ -1,0 +1,223 @@
+; Copyright (c) 2020-present Walmart, Inc.
+;
+; Licensed under the Apache License, Version 2.0 (the "License")
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+(ns ^:no-doc com.walmartlabs.lacinia.pedestal.internal
+  "Internal utilties not part of the public API."
+  (:require
+    [clojure.core.async :refer [chan put!]]
+    [cheshire.core :as cheshire]
+    [com.walmartlabs.lacinia.util :as util]
+    [com.walmartlabs.lacinia.parser :as parser]
+    [clojure.string :as str]
+    [com.walmartlabs.lacinia.validator :as validator]
+    [com.walmartlabs.lacinia.constants :as constants]
+    [com.walmartlabs.lacinia.resolve :as resolve]
+    [com.walmartlabs.lacinia.executor :as executor]
+    [io.pedestal.log :as log]
+    [clojure.java.io :as io]
+    [ring.util.response :as response]
+    [io.pedestal.http.jetty.websockets :as ws]
+    [io.pedestal.http :as http]
+    [com.walmartlabs.lacinia.pedestal.subscriptions :as subscriptions]))
+
+(def ^:private parsed-query-key-path [:request :parsed-lacinia-query])
+
+(defn parse-content-type
+  "Parse `s` as an RFC 2616 media type."
+  [s]
+  (if-let [[_ type _ _ raw-params] (re-matches #"\s*(([^/]+)/([^ ;]+))\s*(\s*;.*)?" (str s))]
+    {:content-type (keyword type)
+     :content-type-params
+     (->> (str/split (str raw-params) #"\s*;\s*")
+          (keep identity)
+          (remove str/blank?)
+          (map #(str/split % #"="))
+          (mapcat (fn [[k v]] [(keyword (str/lower-case k)) (str/trim v)]))
+          (apply hash-map))}))
+
+(defn content-type
+  "Gets the content-type of a request. (without encoding)"
+  [request]
+  (if-let [content-type (get-in request [:headers "content-type"])]
+    (:content-type (parse-content-type content-type))))
+
+(defn on-leave-json-response
+  [context]
+  (let [body (get-in context [:response :body])]
+    (if (map? body)
+      (-> context
+          (assoc-in [:response :headers "Content-Type"] "application/json")
+          (update-in [:response :body] cheshire/generate-string))
+      context)))
+
+(defn failure-response
+  "Generates a bad request Ring response."
+  ([body]
+   (failure-response 400 body))
+  ([status body]
+   {:status status
+    :headers {}
+    :body body}))
+
+(defn message-as-errors
+  [message]
+  {:errors [{:message message}]})
+
+(defn as-errors
+  [exception]
+  {:errors [(util/as-error-map exception)]})
+
+(defn on-enter-query-parser
+  [compiled-schema]
+  (fn [context]
+    (let [{:keys [graphql-query graphql-operation-name]} (:request context)]
+      (try
+        (let [actual-schema (if (map? compiled-schema)
+                              compiled-schema
+                              (compiled-schema))
+              parsed-query (parser/parse-query actual-schema graphql-query graphql-operation-name)]
+          (assoc-in context parsed-query-key-path parsed-query))
+        (catch Exception e
+          (assoc context :response
+                         (failure-response (as-errors e))))))))
+
+(defn on-enter-prepare-query
+  [context]
+  (try
+    (let [{parsed-query :parsed-lacinia-query
+           vars :graphql-vars} (:request context)
+          prepared (parser/prepare-with-query-variables parsed-query vars)
+          compiled-schema (get prepared constants/schema-key)
+          errors (validator/validate compiled-schema prepared {})]
+      (if (seq errors)
+        (assoc context :response (failure-response {:errors errors}))
+        (assoc-in context parsed-query-key-path prepared)))
+    (catch Exception e
+      (assoc context :response
+                     (failure-response (as-errors e))))))
+
+
+(defn ^:private remove-status
+  "Remove the :status key from the :extensions map; remove the :extensions key if that is now empty."
+  [error-map]
+  (if-not (contains? error-map :extensions)
+    error-map
+    (let [error-map' (update error-map :extensions dissoc :status)]
+      (if (-> error-map' :extensions seq)
+        error-map'
+        (dissoc error-map' :extensions)))))
+
+(defn on-leave-status-conversion
+  [context]
+  (let [response (:response context)
+        errors (get-in response [:body :errors])
+        statuses (keep #(-> % :extensions :status) errors)]
+    (if (seq statuses)
+      (let [max-status (reduce max (:status response) statuses)]
+        (-> context
+            (assoc-in [:response :status] max-status)
+            (assoc-in [:response :body :errors]
+                      (map remove-status errors))))
+      context)))
+
+
+(defn ^:private apply-result-to-context
+  [context result]
+  ;; Lacinia changed the contract here is 0.36.0 (to support timeouts), the result
+  ;; maybe an exception thrown during initial processing of the query.
+  (if (instance? Throwable result)
+    (do
+      (log/error :event :execution-exception
+                 :ex result)
+      (assoc context :response (failure-response 500 (as-errors result))))
+    ;; When :data is missing, then a failure occurred during parsing or preparing
+    ;; the request, which indicates a bad request, rather than some failure
+    ;; during execution.
+    (let [status (if (contains? result :data)
+                   200
+                   400)
+          response {:status status
+                    :headers {}
+                    :body result}]
+      (assoc context :response response))))
+
+(defn ^:private execute-query
+  [context]
+  (let [request (:request context)
+        {q :parsed-lacinia-query
+         app-context :lacinia-app-context} request]
+    (executor/execute-query (assoc app-context
+                              constants/parsed-query-key q))))
+
+(defn on-enter-query-excecutor
+  [context]
+  (let [resolver-result (execute-query context)
+        *result (promise)]
+    (resolve/on-deliver! resolver-result
+                         (fn [result]
+                           (deliver *result result)))
+    (apply-result-to-context context @*result)))
+
+(defn on-enter-async-query-executor
+  [context]
+  (let [ch (chan 1)
+        resolver-result (execute-query context)]
+    (resolve/on-deliver! resolver-result
+                         (fn [result]
+                           (->> result
+                                (apply-result-to-context context)
+                                (put! ch))))
+    ch))
+
+(defn on-enter-disallow-subscriptions
+  [context]
+  (if (-> context :request :parsed-lacinia-query parser/operations :type (= :subscription))
+    (assoc context :response (failure-response (message-as-errors "Subscription queries must be processed by the WebSockets endpoint.")))
+    context))
+
+(defn ^:private request-headers-string
+  [headers]
+  (str "{"
+       (->> (assoc headers "Content-Type" "application/json")
+            (map (fn [[k v]]
+                   (str \" (name k) "\": \"" (name v) \")))
+            (str/join ", "))
+       "}"))
+
+(defn graphiql-response
+  [api-path subscriptions-path asset-path ide-headers ide-connection-params]
+  (let [replacements {:asset-path asset-path
+                      :api-path api-path
+                      :subscriptions-path subscriptions-path
+                      :initial-connection-params (cheshire/generate-string ide-connection-params)
+                      :request-headers (request-headers-string ide-headers)}]
+    (-> "com/walmartlabs/lacinia/pedestal/graphiql.html"
+        io/resource
+        slurp
+        (str/replace #"\{\{(.+?)}}" (fn [[_ key]]
+                                      (get replacements (keyword key) "--NO-MATCH--")))
+        response/response
+        (response/content-type "text/html"))))
+
+(defn add-subscriptions-support
+  [service-map compiled-schema subscriptions-path subscription-options]
+  (assoc-in service-map
+            [::http/container-options :context-configurator]
+            ;; The listener-fn is responsible for creating the listener; it is passed
+            ;; the request, response, and the ws-map. In sample code, the ws-map
+            ;; has callbacks such as :on-connect and :on-text, but in our scenario
+            ;; the callbacks are created by the listener-fn, so the value is nil.
+            #(ws/add-ws-endpoints % {subscriptions-path nil}
+                                  {:listener-fn
+                                   (subscriptions/listener-fn-factory compiled-schema subscription-options)})))

--- a/src/com/walmartlabs/lacinia/pedestal/internal.clj
+++ b/src/com/walmartlabs/lacinia/pedestal/internal.clj
@@ -49,7 +49,7 @@
 (defn content-type
   "Gets the content-type of a request. (without encoding)"
   [request]
-  (if-let [content-type (get-in request [:headers "content-type"])]
+  (when-let [content-type (get-in request [:headers "content-type"])]
     (:content-type (parse-content-type content-type))))
 
 (defn on-leave-json-response

--- a/src/com/walmartlabs/lacinia/pedestal/subscriptions.clj
+++ b/src/com/walmartlabs/lacinia/pedestal/subscriptions.clj
@@ -445,7 +445,7 @@
     derived from [[default-subscription-interceptors]].
 
   :init-context
-  : A function returning the base context for the subscription-interceptor]s to operate on.
+  : A function returning the base context for the subscription-interceptors to operate on.
     The function takes the following arguments:
      - the minimal viable context for operation
      - the ServletUpgradeRequest that initiated this connection

--- a/src/com/walmartlabs/lacinia/pedestal/subscriptions.clj
+++ b/src/com/walmartlabs/lacinia/pedestal/subscriptions.clj
@@ -445,7 +445,7 @@
     derived from [[default-subscription-interceptors]].
 
   :init-context
-  : A function returning the base context for the subscription-interceptors to operate on.
+  : A function returning the base context for the subscription-interceptor]s to operate on.
     The function takes the following arguments:
      - the minimal viable context for operation
      - the ServletUpgradeRequest that initiated this connection

--- a/src/com/walmartlabs/lacinia/pedestal2.clj
+++ b/src/com/walmartlabs/lacinia/pedestal2.clj
@@ -1,3 +1,17 @@
+; Copyright (c) 2020-present Walmart, Inc.
+;
+; Licensed under the Apache License, Version 2.0 (the "License")
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
 (ns ^{:added "0.14.0"} com.walmartlabs.lacinia.pedestal2
   "A replacement for com.walmartlabs.lacinia.pedestal that is less complected, and supports
    multiple schemas."

--- a/src/com/walmartlabs/lacinia/pedestal2.clj
+++ b/src/com/walmartlabs/lacinia/pedestal2.clj
@@ -13,8 +13,8 @@
 ; limitations under the License.
 
 (ns ^{:added "0.14.0"} com.walmartlabs.lacinia.pedestal2
-  "A replacement for com.walmartlabs.lacinia.pedestal that is less complected, and supports
-   multiple schemas."
+  "Utilities for creating handlers, interceptors, routes, and service maps needed by a Pedestal service
+  that exposes a GraphQL API and GraphiQL IDE."
   (:require
     [clojure.string :as str]
     [cheshire.core :as cheshire]

--- a/src/com/walmartlabs/lacinia/pedestal2.clj
+++ b/src/com/walmartlabs/lacinia/pedestal2.clj
@@ -234,6 +234,9 @@
   The defaults put the GraphQL API at `/api` and the GraphiQL IDE at `/ide` (and subscriptions endpoint
   at `/ws`).
 
+  Unlike earlier versions of lacinia-pedestal, only POST is supported, and the content type must
+  be `application/json`.
+
   compiled-schema is either the schema or a function returning the schema.
 
   options is a map combining options needed by [[graphiql-ide-route]] and [[listener-fn-factory]].

--- a/src/com/walmartlabs/lacinia/pedestal2.clj
+++ b/src/com/walmartlabs/lacinia/pedestal2.clj
@@ -1,0 +1,262 @@
+(ns ^{:added "0.14.0"} com.walmartlabs.lacinia.pedestal2
+  "A replacement for com.walmartlabs.lacinia.pedestal that is less complected, and supports
+   multiple schemas."
+  (:require
+    [clojure.string :as str]
+    [cheshire.core :as cheshire]
+    [ring.util.response :as response]
+    [io.pedestal.interceptor :refer [interceptor]]
+    [io.pedestal.http :as http]
+    [com.walmartlabs.lacinia.pedestal.internal :as internal]
+    [com.walmartlabs.lacinia.pedestal.interceptors :as interceptors]))
+
+(def json-response-interceptor
+  "An interceptor that sees if the response body is a map and, if so,
+  converts the map to JSON and sets the response Content-Type header."
+  (interceptor
+    {:name ::json-response
+     :leave internal/on-leave-json-response}))
+
+(def body-data-interceptor
+  "Converts the POSTed body from a input stream into a string, or rejects the request
+  with a 400 response if the content type is not application/json."
+  (interceptor
+    {:name ::body-data
+     :enter (fn [context]
+              (let [{:keys [content-type]} (-> context :request internal/content-type)]
+                (if (= content-type :application/json)
+                  (update-in context [:request :body] slurp)
+                  (assoc context :response (internal/failure-response "Must be application/json")))))}))
+
+(def graphql-data-interceptor
+  "Comes after [[body-data-interceptor]], extracts the JSON query and other data into request keys
+  :graphql-query (the query document as a string),
+  :graphql-vars (a map)
+  and :graphql-operation-name (a string).
+
+  Comes after [[body-data-interceptor]]."
+  (interceptor
+    {:name ::graphql-data
+     :enter (fn [context]
+              (try
+                (let [payload (-> context :request :body (cheshire/parse-string true))
+                      {:keys [query variables]
+                       operation-name :operationName} payload]
+                  (update context :request
+                          assoc
+                          :graphql-query query
+                          :graphql-vars variables
+                          :graphql-operation-name operation-name))
+                (catch Exception e
+                  (assoc context :response
+                                 (internal/failure-response
+                                   {:message (str "Invalid request: " (.getMessage e))})))))}))
+
+(def missing-query-interceptor
+  "Rejects the request with a 400 response is the JSON query variable is missing or blank.
+
+  Comes after [[graphql-data-interceptor]]."
+  (interceptor
+    {:name ::missing-query
+     :enter (fn [context]
+              (if (-> context :request :graphql-query str/blank?)
+                (assoc context :response
+                               (internal/failure-response "JSON 'query' key is missing or blank"))
+                context))}))
+
+(defn query-parser-interceptor
+  "Given a compiled schema, returns an interceptor that parses the query.
+
+   `compiled-schema` may be the actual compiled schema, or a no-arguments function
+   that returns the compiled schema.
+
+   Expected to come after [[missing-query-interceptor]] in the interceptor chain.
+
+   Adds a new request key, :parsed-lacinia-query, containing the parsed query.
+
+   Before execution, [[prepare-query-interceptor]] injects query variables and performs
+   validations."
+  [compiled-schema]
+  (interceptor
+    {:name ::query-parser
+     :enter (internal/on-enter-query-parser compiled-schema)}))
+
+(def prepare-query-interceptor
+  "Prepares (with query variables) and validates the query, previously parsed
+  by [[query-parser-interceptor]]."
+  (interceptor
+    {:name ::prepare-query
+     :enter internal/on-enter-prepare-query}))
+
+(def status-conversion-interceptor
+  "Checks to see if any error map in the :errors key of the response
+  contains a :status value (under it's :extensions key).
+  If so, the maximum status value of such errors is found and used as the status of the overall response, and the
+  :status key is dissoc'ed from all errors."
+  (interceptor
+    {:name ::status-conversion
+     :leave internal/on-leave-status-conversion}))
+
+(def disallow-subscriptions-interceptor
+  "Handles requests for subscriptions.  Subscription requests must only be sent to the subscriptions web-socket, not the
+  general query endpoint, so any subscription request received in this pipeline is a bad request."
+  (interceptor
+    {:name ::disallow-subscriptions
+     :enter internal/on-enter-disallow-subscriptions}))
+
+(def query-executor-handler
+  "The handler at the end of interceptor chain, invokes Lacinia to
+  execute the query and return the main response.
+
+  The handler adds the Ring request map as the :request key to the provided
+  app-context before executing the query.
+
+  This comes last in the interceptor chain."
+  (interceptor
+    {:name ::query-executor
+     :enter internal/on-enter-query-excecutor}))
+
+(def async-query-executor-handler
+  "Async variant of [[query-executor-handler]] which returns a channel that conveys the
+  updated context."
+  (interceptor
+    {:name ::async-query-executor
+     :enter internal/on-enter-async-query-executor}))
+
+(defn default-interceptors
+  "Returns the default set of GraphQL interceptors, as a seq:
+
+    * ::json-response [[json-response-interceptor]]
+    * ::body-data [[body-data-interceptor]]
+    * ::graphql-data [[graphql-data-interceptor]]
+    * ::status-conversion [[status-conversion-interceptor]]
+    * ::missing-query [[missing-query-interceptor]]
+    * ::query-parser [[query-parser-interceptor]]
+    * ::disallow-subscriptions [[disallow-subscriptions-interceptor]]
+    * ::prepare-query [[prepare-query-interceptor]]
+    * ::com.walmartlabs.lacinia.pedestal/inject-app-context [[inject-app-context-interceptor]]
+    * ::query-executor [[query-executor-handler]]
+
+  `compiled-schema` may be the actual compiled schema, or a no-arguments function that returns the compiled schema.
+
+  `app-context` is the application context that will be passed into all resolvers
+  (the [[inject-app-context-interceptor]] adds a :request key to this map).
+
+  Often, this list of interceptors is augmented by calls to [[inject]]."
+  [compiled-schema app-context]
+  [json-response-interceptor
+   body-data-interceptor
+   graphql-data-interceptor
+   status-conversion-interceptor
+   missing-query-interceptor
+   (query-parser-interceptor compiled-schema)
+   disallow-subscriptions-interceptor
+   prepare-query-interceptor
+   (interceptors/inject-app-context-interceptor app-context)
+   query-executor-handler])
+
+(defn graphiql-asset-routes
+  "Returns a set of routes for retrieving GraphiQL assets (CSS and JS)."
+  [asset-path]
+  (let [asset-path' (str asset-path "/*path")
+        asset-get-handler (fn [request]
+                            (response/resource-response (-> request :path-params :path)
+                                                        {:root "graphiql"}))
+        asset-head-handler #(-> %
+                                asset-get-handler
+                                (assoc :body nil))]
+    #{[asset-path' :get asset-get-handler :route-name ::graphiql-get-assets]
+      [asset-path' :head asset-head-handler :route-name ::graphiql-head-assets]}))
+
+(def ^:private default-api-path "/api")
+(def ^:private default-ide-path "/ide")
+(def ^:private default-asset-path "/assets/graphiql")
+(def ^:private default-subscriptions-path "/ws")
+
+(defn graphiql-ide-handler
+  "Returns a handler for the GraphiQL IDE.
+
+  A route can be constructed from this handler.
+
+  Options:
+
+  :api-path (default: \"/api\")
+  : Path at which GraphQL requests are serviced.
+
+  :ide-path (default: \"/ide\")
+  : Path from which the GraphiQL IDE can be loaded.
+
+  :asset-path (default: \"/assets/graphiql\")
+  : Path from which the JavaScript and CSS assets may be loaded.
+
+  :subscriptions-path (default: \"/ws\")
+  : Path for web socket connections, to handle GraphQL subscriptions.
+
+  :ide-headers
+  : A map from header name to header value. Keys and values may be strings, keywords,
+    or symbols and are converted to strings using clojure.core/name.
+    These define additional headers to be included in the requests from the IDE.
+    Typically, the headers are used to identify and authenticate the requests.
+
+  :ide-connection-params
+  : A value that is used with the GraphiQL IDE; this value is converted to JSON,
+    and becomes the connectionParams passed in the initial subscription web service call;
+    this can be used to identify and authenticate subscription requests."
+  [options]
+  (let [{:keys [api-path ide-path asset-path subscriptions-path ide-headers ide-connection-params route-name]
+         :or {ide-path default-ide-path
+              api-path default-api-path
+              asset-path default-asset-path
+              subscriptions-path default-subscriptions-path
+              route-name ::graphiql-ide}} options
+        response (internal/graphiql-response
+                   api-path subscriptions-path asset-path ide-headers ide-connection-params)]
+    (fn [_]
+      response)))
+
+(defn enable-subscriptions
+  "Updates a Pedestal service map to add support for subscriptions.
+
+  As elsewhere, the compiled-schema may be a function that returns the compiled schema.
+
+  The subscription options are documented at [[listener-fn-factory]]."
+  [service-map subscriptions-path compiled-schema subscription-options]
+  (internal/add-subscriptions-support service-map compiled-schema subscriptions-path subscription-options))
+
+(defn enable-graphiql
+  "Disables secure headers in the service map, a prerequisite for GraphiQL requests to operate."
+  [service-map]
+  (assoc service-map ::http/secure-headers nil))
+
+(defn default-service
+  "Returns a default Pedestal service map, with subscriptions and GraphiQL enabled.
+
+  The defaults put the GraphQL API at `/api` and the GraphiQL IDE at `/ide` (and subscriptions endpoint
+  at `/ws`).
+
+  compiled-schema is either the schema, or a function returning the schema.
+
+  options is a map combining options needed by [[graphiql-ide-route]] and [[listener-fn-factory]].
+
+  It may also contain keys :app-context and :port (which defaults to 8888).
+
+  This is useful for initial development and exploration, but applications with any more needs should construct
+  their service map directly."
+  [compiled-schema options]
+  (let [{:keys [api-path ide-path asset-path subscriptions-path app-context port]
+         :or {api-path default-api-path
+              ide-path default-ide-path
+              asset-path default-asset-path
+              subscriptions-path default-subscriptions-path
+              port 8888}} options
+        interceptors (default-interceptors compiled-schema app-context)
+        routes (into #{[api-path :post interceptors ::graphql-api]
+                       [ide-path :get (graphiql-ide-handler options) ::graphiql-ide]}
+                     (graphiql-asset-routes asset-path))]
+    (-> {:env :dev
+         ::http/routes routes
+         ::http/port port
+         ::http/type :jetty
+         ::http/join? false}
+        (enable-subscriptions subscriptions-path compiled-schema options)
+        (enable-graphiql))))

--- a/src/com/walmartlabs/lacinia/pedestal2.clj
+++ b/src/com/walmartlabs/lacinia/pedestal2.clj
@@ -23,7 +23,7 @@
   (interceptor
     {:name ::body-data
      :enter (fn [context]
-              (let [{:keys [content-type]} (-> context :request internal/content-type)]
+              (let [content-type (-> context :request internal/content-type)]
                 (if (= content-type :application/json)
                   (update-in context [:request :body] slurp)
                   (assoc context :response (internal/failure-response "Must be application/json")))))}))
@@ -249,8 +249,8 @@
               asset-path default-asset-path
               port 8888}} options
         interceptors (default-interceptors compiled-schema app-context)
-        routes (into #{[api-path :post interceptors ::graphql-api]
-                       [ide-path :get (graphiql-ide-handler options) ::graphiql-ide]}
+        routes (into #{[api-path :post interceptors :route-name ::graphql-api]
+                       [ide-path :get (graphiql-ide-handler options) :route-name ::graphiql-ide]}
                      (graphiql-asset-routes asset-path))]
     (-> {:env :dev
          ::http/routes routes

--- a/test/com/walmartlabs/lacinia/indirect_schema_test.clj
+++ b/test/com/walmartlabs/lacinia/indirect_schema_test.clj
@@ -27,7 +27,7 @@
                                           :subscriptions true
                                           :keep-alive-ms 200}))
 
-(use-fixtures :each subscriptions-fixture)
+(use-fixtures :each (subscriptions-fixture))
 
 (deftest standard-json-request
   (let [response

--- a/test/com/walmartlabs/lacinia/parse_test.clj
+++ b/test/com/walmartlabs/lacinia/parse_test.clj
@@ -15,12 +15,11 @@
 (ns com.walmartlabs.lacinia.parse-test
   (:require
     [clojure.test :refer :all]
-    [com.walmartlabs.lacinia.pedestal :as lp]))
-
+    [com.walmartlabs.lacinia.pedestal.internal :refer [parse-content-type]]))
 
 (deftest parse-test
   (are [s r]
-    (= r (lp/parse-content-type s))
+    (= r (parse-content-type s))
 
     "application/json"
     {:content-type :application/json

--- a/test/com/walmartlabs/lacinia/parse_test.clj
+++ b/test/com/walmartlabs/lacinia/parse_test.clj
@@ -14,7 +14,7 @@
 
 (ns com.walmartlabs.lacinia.parse-test
   (:require
-    [clojure.test :refer :all]
+    [clojure.test :refer [deftest are]]
     [com.walmartlabs.lacinia.pedestal.internal :refer [parse-content-type]]))
 
 (deftest parse-test

--- a/test/com/walmartlabs/lacinia/pedestal/subscription_interceptors_test.clj
+++ b/test/com/walmartlabs/lacinia/pedestal/subscription_interceptors_test.clj
@@ -15,7 +15,6 @@
 (ns com.walmartlabs.lacinia.pedestal.subscription-interceptors-test
   (:require
     [clojure.test :refer [deftest is use-fixtures]]
-    [clojure.core.async :refer [chan alt!! put! timeout]]
     [com.walmartlabs.lacinia.pedestal :refer [inject]]
     [com.walmartlabs.lacinia.test-utils
      :refer [test-server-fixture *ping-subscribes *ping-cleanups

--- a/test/com/walmartlabs/lacinia/pedestal/subscription_interceptors_test.clj
+++ b/test/com/walmartlabs/lacinia/pedestal/subscription_interceptors_test.clj
@@ -64,7 +64,7 @@
                                           :keep-alive-ms 200}
                                          options-builder))
 
-(use-fixtures :each subscriptions-fixture)
+(use-fixtures :each (subscriptions-fixture))
 
 (deftest added-interceptor-is-invoked
   (send-init)

--- a/test/com/walmartlabs/lacinia/pedestal/subscriptions_test.clj
+++ b/test/com/walmartlabs/lacinia/pedestal/subscriptions_test.clj
@@ -27,7 +27,7 @@
 
 (use-fixtures :once (test-server-fixture {:subscriptions true
                                           :keep-alive-ms 200}))
-(use-fixtures :each subscriptions-fixture)
+(use-fixtures :each (subscriptions-fixture))
 
 (deftest connect-with-ws
   (send-init)

--- a/test/com/walmartlabs/lacinia/pedestal2_test.clj
+++ b/test/com/walmartlabs/lacinia/pedestal2_test.clj
@@ -1,8 +1,22 @@
+; Copyright (c) 2020-present Walmart, Inc.
+;
+; Licensed under the Apache License, Version 2.0 (the "License")
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
 (ns com.walmartlabs.lacinia.pedestal2-test
   "Tests for the new pedestal2 namespace.
 
-  Since the majority of the code goes through the shared internal library, these tests are light as long as
-  the original lacinia.pedestal namespace exists."
+  Since the majority of the code goes through the shared internal namespace, these tests are light as long as
+  the testing of the original lacinia.pedestal namespace exists."
   (:require
     [clojure.test :refer [deftest is use-fixtures]]
     [com.walmartlabs.lacinia.pedestal2 :as p2]

--- a/test/com/walmartlabs/lacinia/pedestal2_test.clj
+++ b/test/com/walmartlabs/lacinia/pedestal2_test.clj
@@ -1,0 +1,82 @@
+(ns com.walmartlabs.lacinia.pedestal2-test
+  "Tests for the new pedestal2 namespace.
+
+  Since the majority of the code goes through the shared internal library, these tests are light as long as
+  the original lacinia.pedestal namespace exists."
+  (:require
+    [clojure.test :refer [deftest is use-fixtures]]
+    [com.walmartlabs.lacinia.pedestal2 :as p2]
+    [com.walmartlabs.lacinia.test-utils :as tu]
+    [io.pedestal.http :as http]
+    [cheshire.core :as cheshire]
+    [clj-http.client :as client]
+    [com.walmartlabs.test-reporting :refer [reporting]]))
+
+(defn prune
+  [response]
+  (select-keys response [:status :body]))
+
+(defn server-fixture
+  [f]
+  (reset! tu/*ping-subscribes 0)
+  (reset! tu/*ping-cleanups 0)
+  (let [service (-> (tu/compile-schema)
+                    (p2/default-service nil)
+                    http/create-server
+                    http/start)]
+    (try
+      (f)
+      (finally
+        (http/stop service)))))
+
+(use-fixtures :once server-fixture)
+(use-fixtures :each (tu/subscriptions-fixture "ws://localhost:8888/ws"))
+
+(defn send-request
+  "Sends a GraphQL request to the server and returns the response."
+  ([query]
+   (send-request query nil))
+  ([query vars]
+   (-> {:method :post
+        :url "http://localhost:8888/api"
+        :headers {"Content-Type" "application/json"}
+        :throw-exceptions false
+        :body (cheshire/generate-string {:query query
+                                         :variables vars})}
+       client/request
+       (update :body #(try
+                        (cheshire/parse-string % true)
+                        (catch Exception t
+                          %))))))
+
+(deftest basic-request
+  (let [response (send-request "{ echo(value: \"hello\") { value method }}")]
+    (reporting response
+               (is (= {:status 200
+                       :body {:data {:echo {:method "post"
+                                            :value "hello"}}}}
+                      (prune response)))
+               (is (= {:data {:echo {:method "post"
+                                     :value "hello"}}}
+                      (:body response))))))
+
+(deftest missing-query
+  (let [response (send-request nil)]
+    (reporting response
+               (is (= {:body "JSON 'query' key is missing or blank"
+                       :status 400}
+                      (prune response))))))
+
+(deftest must-be-json
+  (let [response (client/post "http://localhost:8888/api"
+                              {:headers {"Content-Type" "text/plain"}
+                               :body "does not matter"
+                               :throw-exceptions false})]
+    (reporting response
+               (is (= {:body "Must be application/json"
+                       :status 400}
+                      (prune response))))))
+
+(deftest subscriptions-ws-request
+  (tu/send-init)
+  (tu/expect-message {:type "connection_ack"}))


### PR DESCRIPTION
I decided that I wanted a "complete set" of interceptors in the new namespace, since you often need to reference them by fully qualified name when injecting new interceptors into the stack; it makes sense to me that if you use `pedestal2/default-interceptors` the interceptors are (except for the one) in the `pedestal2` namespace.