### PR TITLE
Enable inject function to remove an interceptor

### DIFF
--- a/src/com/walmartlabs/lacinia/pedestal.clj
+++ b/src/com/walmartlabs/lacinia/pedestal.clj
@@ -86,6 +86,8 @@
 
   relative-position may be :before, :after, or :replace.
 
+  For :replace, the new interceptor may be nil, in which case the interceptor is removed.
+
   The named interceptor must exist, or an exception is thrown."
   {:added "0.7.0"}
   [interceptors new-interceptor relative-position interceptor-name]
@@ -105,7 +107,9 @@
                                      (conj result interceptor new-interceptor)
 
                                      :replace
-                                     (conj result new-interceptor)))))
+                                     (if new-interceptor
+                                       (conj result new-interceptor)
+                                       result)))))
                              []
                              interceptors)]
     (when-not @*found?
@@ -127,7 +131,7 @@
 (s/fdef inject
   :ret ::interceptors
   :args (s/cat :interceptors ::interceptors
-               :new-interceptor ::interceptor
+               :new-interceptor (s/nilable ::interceptor)
                :relative-position #{:before :after :replace}
                :interceptor-name keyword?))
 

--- a/test/com/walmartlabs/lacinia/pedestal_test.clj
+++ b/test/com/walmartlabs/lacinia/pedestal_test.clj
@@ -161,6 +161,13 @@
     (is (= [fred wilma]
            (inject [fred barney] wilma :replace :barney)))))
 
+(deftest inject-remove
+  (let [fred {:name :fred}
+        barney {:name :barney}
+        wilma {:name :wilma}]
+    (is (= [fred wilma]
+           (inject [fred barney wilma] nil :replace :barney)))))
+
 (deftest inject-skips-fns
   (let [fred identity
         barney {:name :barney}


### PR DESCRIPTION
This is less cumbersome than `(remove #(= (:name %) xyz) interceptors)`, ensures the result is a vector (important!), works well in a `->` chain, and keeps the checking that the name could be found.