### PR TITLE
Add ability for interceptors to handle exceptions in lacinia

### DIFF
--- a/dev-resources/com/walmartlabs/lacinia/test_utils.clj
+++ b/dev-resources/com/walmartlabs/lacinia/test_utils.clj
@@ -3,6 +3,7 @@
     [clojure.test :refer [is]]
     [clj-http.client :as client]
     [io.pedestal.http :as http]
+    [io.pedestal.interceptor :refer [interceptor]]
     [com.walmartlabs.lacinia.pedestal :as lp]
     [clojure.core.async :refer [timeout alt!! chan put!]]
     [clojure.java.io :as io]
@@ -213,3 +214,12 @@
         (finally
           (log/debug :reason ::test-end)
           (g/close session))))))
+
+(defn error-proof-interceptor
+  "Error interceptor that records the last context / exception it has been called with."
+  [proof]
+  (interceptor
+   {:name ::proof
+    :error (fn [ctx ex]
+             (reset! proof [ctx ex])
+             (throw ex))}))

--- a/src/com/walmartlabs/lacinia/pedestal.clj
+++ b/src/com/walmartlabs/lacinia/pedestal.clj
@@ -249,8 +249,8 @@
 
   Deprecated: Use [[pedestal2/query-executor-handler]] instead."
   (interceptor
-    {:name ::query-executor
-     :enter (internal/on-enter-query-excecutor ::query-executor)}))
+   {:name  ::query-executor
+    :enter (internal/on-enter-query-executor ::query-executor)}))
 
 (def ^{:added "0.2.0"
        :deprecated "0.14.0"} async-query-executor-handler

--- a/src/com/walmartlabs/lacinia/pedestal.clj
+++ b/src/com/walmartlabs/lacinia/pedestal.clj
@@ -250,7 +250,7 @@
   Deprecated: Use [[pedestal2/query-executor-handler]] instead."
   (interceptor
     {:name ::query-executor
-     :enter (internal/on-enter-query-excecutor ::query-executor :enter)}))
+     :enter (internal/on-enter-query-excecutor ::query-executor)}))
 
 (def ^{:added "0.2.0"
        :deprecated "0.14.0"} async-query-executor-handler
@@ -260,7 +260,7 @@
   Deprecated: Use [[pedestal2/async-query-executor-handler]] instead."
   (interceptor
     {:name ::async-query-executor
-     :enter (internal/on-enter-async-query-executor ::async-query-executor :enter)}))
+     :enter (internal/on-enter-async-query-executor ::async-query-executor)}))
 
 (def ^{:added "0.3.0"
        :deprecated "0.14.0"} disallow-subscriptions-interceptor

--- a/src/com/walmartlabs/lacinia/pedestal/internal.clj
+++ b/src/com/walmartlabs/lacinia/pedestal/internal.clj
@@ -185,7 +185,7 @@
     (executor/execute-query (assoc app-context
                               constants/parsed-query-key q))))
 
-(defn on-enter-query-excecutor
+(defn on-enter-query-executor
   [interceptor-name]
   (fn [context]
     (let [resolver-result (execute-query context)

--- a/src/com/walmartlabs/lacinia/pedestal2.clj
+++ b/src/com/walmartlabs/lacinia/pedestal2.clj
@@ -133,14 +133,14 @@
   This comes last in the interceptor chain."
   (interceptor
     {:name ::query-executor
-     :enter (internal/on-enter-query-excecutor ::query-executor :enter)}))
+     :enter (internal/on-enter-query-excecutor ::query-executor)}))
 
 (def async-query-executor-handler
   "Async variant of [[query-executor-handler]] which returns a channel that conveys the
   updated context."
   (interceptor
     {:name ::async-query-executor
-     :enter (internal/on-enter-async-query-executor ::async-query-executor :enter)}))
+     :enter (internal/on-enter-async-query-executor ::async-query-executor)}))
 
 (defn default-interceptors
   "Returns the default set of GraphQL interceptors, as a seq:

--- a/src/com/walmartlabs/lacinia/pedestal2.clj
+++ b/src/com/walmartlabs/lacinia/pedestal2.clj
@@ -132,8 +132,8 @@
 
   This comes last in the interceptor chain."
   (interceptor
-    {:name ::query-executor
-     :enter (internal/on-enter-query-excecutor ::query-executor)}))
+   {:name  ::query-executor
+    :enter (internal/on-enter-query-executor ::query-executor)}))
 
 (def async-query-executor-handler
   "Async variant of [[query-executor-handler]] which returns a channel that conveys the

--- a/test/com/walmartlabs/lacinia/pedestal2_test.clj
+++ b/test/com/walmartlabs/lacinia/pedestal2_test.clj
@@ -91,6 +91,12 @@
                        :status 400}
                       (prune response))))))
 
+(deftest can-return-failure-response
+  (let [response (send-request "{ fail }")]
+    (is (= {:body {:errors [{:message "resolver exception"}]}
+            :status 500}
+           (select-keys response [:status :body])))))
+
 (deftest subscriptions-ws-request
   (tu/send-init)
   (tu/expect-message {:type "connection_ack"}))

--- a/test/com/walmartlabs/lacinia/pedestal_error_test.clj
+++ b/test/com/walmartlabs/lacinia/pedestal_error_test.clj
@@ -1,0 +1,64 @@
+; Copyright (c) 2017-present Walmart, Inc.
+;
+; Licensed under the Apache License, Version 2.0 (the "License")
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+(ns com.walmartlabs.lacinia.pedestal-error-test
+  (:require
+   [clojure.test :refer [deftest is use-fixtures]]
+   [com.walmartlabs.lacinia.pedestal :refer [default-interceptors inject] :as lp]
+   [com.walmartlabs.lacinia.test-utils :refer [test-server-fixture
+                                               send-request]]
+   [clojure.spec.test.alpha :as stest]
+   [io.pedestal.interceptor :refer [interceptor]]))
+
+(stest/instrument)
+
+(defn proof-interceptor
+  "Interceptor that records how often its error function is called"
+  [proof]
+  (interceptor
+   {:name ::proof
+    :error (fn [_ ex]
+             (swap! proof inc)
+             (throw ex))}))
+
+(def prior-error-proof (atom 0))
+(def post-error-proof (atom 0))
+
+(use-fixtures :once (test-server-fixture {:graphiql true}
+                                         (fn [schema]
+                                           {:interceptors (-> (default-interceptors schema {})
+                                                              ;; Should not be called
+                                                              (inject (proof-interceptor prior-error-proof)
+                                                                      :before ::lp/error-response)
+                                                              ;; Should be called
+                                                              (inject (proof-interceptor post-error-proof)
+                                                                      :after  ::lp/error-response))})))
+
+(deftest can-return-failure-response
+  (let [response (send-request "{ fail }")]
+    (is (= {:body {:errors [{:message "resolver exception"}]}
+            :status 500}
+           (select-keys response [:status :body])))))
+
+(deftest calls-post-error-interceptor
+  (reset! prior-error-proof 0)
+  (reset! post-error-proof 0)
+  (send-request "{ fail }")
+  (is (= 1 @post-error-proof)))
+
+(deftest skips-prior-error-interceptor
+  (reset! prior-error-proof 0)
+  (reset! post-error-proof 0)
+  (send-request "{ fail }")
+  (is (= 0 @prior-error-proof)))

--- a/test/com/walmartlabs/lacinia/pedestal_test.clj
+++ b/test/com/walmartlabs/lacinia/pedestal_test.clj
@@ -136,6 +136,12 @@
             :status 400}
            (select-keys response [:status :body])))))
 
+(deftest can-return-failure-response
+  (let [response (send-request "{ fail }")]
+    (is (= {:body {:errors [{:message "resolver exception"}]}
+            :status 500}
+           (select-keys response [:status :body])))))
+
 (deftest inject-not-found
   (is (thrown-with-msg? ExceptionInfo #"Could not find existing interceptor"
                         (inject [{:name :fred}] {:name :barney} :before :bam-bam))))


### PR DESCRIPTION
This change enables the use of standard pedestal error handling for errors raised in the interceptor stack or in lacinia itself. It does so by moving error response generation to the very end of the (outbound) interceptor stack. End users can then inject interceptors prior to it to handle or log exceptions as desired.

As it stands, this is only applicable to the synchronous query executor. I would also like to invoke the same error interceptors with exceptions occurring on the asynchronous path, but am currently unable to figure out how exceptions occurring in channels should be handled in pedestal.

If we do figure that out, we can simplify some of the code here as there are now two error paths (one for sync, one for async).

Besides fixing the asynchronous error handling case, it may also be beneficial to move the default error logging to its own separate interceptor. Our use case will directly send these to Rollbar, so the default logging is not required. Another benefit is that exceptions occurring inside the pedestal interceptors can also be logged.

I have verified that these changes work in our application and am eager to make changes if so desired :)!
