### PR TITLE
Update docs with pedestal2

### DIFF
--- a/docs/async.rst
+++ b/docs/async.rst
@@ -1,18 +1,20 @@
 Async
 =====
 
-By default, Lacinia-Pedestal blocks while executing the query.
+By default, Lacinia-Pedestal blocks while executing the query. The default
+pedestal interceptor stack includes as synchronous query execution handler,
+``com.walmartlabs.lacinia.pedestal2/query-executor-handler``.
 
-The ``:async`` option, passed to ``com.walmartlabs.lacina.pedestal/pedestal-server``
-will enable async execution.
+Lacinia also provides an asynchronous query execution handler:
+``com.walmartlabs.lacinia.pedestal2/async-query-executor-handler``.
 
-In async mode, execution starts on a Pedestal request processing thread,
-but (at the discretion of individual field resolver functions) may
-continue on other threads.
+When used in the interceptor stack, execution starts on a Pedestal request
+processing thread, but (at the discretion of individual field resolver
+functions) may continue on other threads.
 
-Further, the return value from the Pedestal handler is a channel, forcing
-Pedestal to switch to async mode.
+Further, the return value from the interceptor is a channel, forcing Pedestal to
+switch to async mode.
 
-Lacinia-Pedestal does not impose any restrictions on number of requests it will attempt
-to process concurrently; you should provide application-specific
+Lacinia-Pedestal does not impose any restrictions on number of requests it will
+attempt to process concurrently; you should provide application-specific
 interceptors to rate limit requests, or risk saturating your server.

--- a/docs/interceptors.rst
+++ b/docs/interceptors.rst
@@ -1,24 +1,26 @@
 Interceptors
 =============
 
-`com.walmartlabs.lacinia.pedestal <https://walmartlabs.github.io/apidocs/lacinia-pedestal/com.walmartlabs.lacinia.pedestal.html>` defines Pedestal `interceptors <http://pedestal.io/reference/interceptors>` and supporting code.
+`com.walmartlabs.lacinia.pedestal2 <https://walmartlabs.github.io/apidocs/lacinia-pedestal/com.walmartlabs.lacinia.pedestal2.html>`_ defines Pedestal `interceptors <http://pedestal.io/reference/interceptors>`_ and supporting code.
 
-The `inject <https://walmartlabs.github.io/apidocs/lacinia-pedestal/com.walmartlabs.lacinia.pedestal.html#var-inject>` function (added in 0.7.0) adds (or replaces) an interceptor to a seq of interceptors.
+The `inject <https://walmartlabs.github.io/apidocs/lacinia-pedestal/com.walmartlabs.lacinia.pedestal.html#var-inject>`_ function (added in 0.7.0) adds (or replaces) an interceptor to a seq of interceptors.
 
 Example
 --------
 
-Example to inject an interceptor that adds a `:custom-user-info-key` to the Lacinia's app-context (for example with extracted authentication information from the request).
+Example of injecting an interceptor that adds a `:custom-user-info-key` to the Lacinia's app-context (for example with extracted authentication information from the request).
+::
 
     (ns server
       (:require
        [com.stuartsierra.component :as component]
+       [com.walmartlabs.lacinia.p2 :as p2]
        [com.walmartlabs.lacinia.pedestal :as pedestal]
        [io.pedestal.http :as http]))
     
     (def user-info-interceptor
       {:enter (fn [{:keys [request] :as context}]
-        ;; Retrieve information from for example the request
+        ;; Retrieve information from the request, for example
         (assoc-in context [:request :lacinia-app-context :custom-user-info-key] :some-value})
     
     (defn- inject-user-info-interceptor
@@ -52,7 +54,8 @@ Example to inject an interceptor that adds a `:custom-user-info-key` to the Laci
         (http/stop server)
         (assoc this :server nil)))
 
-Adding the above interceptor makes the `:custom-user-info-key` information available in for example a resolver.
+Adding the above interceptor makes the `:custom-user-info-key` information available in, for example, a resolver.
+::
 
     (defn- some-resolver
       [ds]

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -1,7 +1,15 @@
 Overview
 ========
 
-The main function used in Lacinia-Pedestal is ``com.walmartlabs.lacinia.pedestal/pedestal-service``.
+The main function used in Lacinia-Pedestal is ``com.walmartlabs.lacinia.pedestal2/default-service``.
+
+... warning::
+
+  The newer com.walmartlabs.lacinia.pedestal2 namespace is recommended over the
+  now-deprecated com.walmartlabs.lacinia.pedestal namespace. The new ns was
+  introduced to maintain backwards compatibility, but be aware of which you use,
+  as the default urls served differ with each namespace. This guide assumes you
+  are using the latest lacinia and the pedestal2 defaults.
 
 You start with a schema file, :file:`resources/hello-world-schema.edn`, in this example:
 
@@ -21,10 +29,10 @@ From there there are three steps:
 
 At the end of this, an instance of `Jetty <http://www.eclipse.org/jetty/>`_ is launched on port 8888.
 
-The GraphQL endpoint will be at ``http://localhost:8888/graphql`` and the GraphIQL client will be at
-``http://localhost:8888/``.
+The GraphQL endpoint will be at ``http://localhost:8888/api`` and the GraphIQL client will be at
+``http://localhost:8888/ide``.
 
-The options map provided to ``pedestal-service`` allow a number of features of Lacinia-Pedestal
+The options map provided to ``default-service`` allow a number of features of Lacinia-Pedestal
 to be configured or customized.
 
 Lacinia-Pedestal supports GET and POSTs in a number of different formats.

--- a/docs/request.rst
+++ b/docs/request.rst
@@ -3,7 +3,7 @@ Request Format
 
 Clients may send either a HTTP GET or HTTP POST request to execute a query.
 
-In both cases, the request path will (by default) be ``/graphql``.
+In both cases, the request path will (by default) be ``/api``.
 
 GET
 ---

--- a/docs/subscriptions.rst
+++ b/docs/subscriptions.rst
@@ -1,7 +1,7 @@
 Subscriptions
 =============
 
-Subscriptions are an exciting, and relative recent, addition to GraphQL.
+Subscriptions are an exciting, and relatively recent, addition to GraphQL.
 
 Subscriptions are a way for a client to request notifications about arbitrary events defined by the server;
 this parallels how a query exposes arbitrary data defined by the server.
@@ -50,7 +50,7 @@ the client is lost due to a network partition, or when the streamer passes nil t
 Configuration
 -------------
 
-Subscriptions are enabled using the options map passed to ``com.walmartlabs.lacina.pedestal/pedestal-service``.
+Subscriptions are enabled using the options map passed to ``com.walmartlabs.lacinia.pedestal2/default-service``.
 
 The following keys are used:
 

--- a/src/com/walmartlabs/lacinia/pedestal.clj
+++ b/src/com/walmartlabs/lacinia/pedestal.clj
@@ -151,7 +151,7 @@
 (def ^{:deprecated "0.14.0"} body-data-interceptor
   "Converts the POSTed body from a input stream into a string.
 
-  Deprecated: Use [[pedetal2/body-data-interceptor]] instead."
+  Deprecated: Use [[pedestal2/body-data-interceptor]] instead."
   (interceptor
     {:name ::body-data
      :enter (fn [context]
@@ -224,7 +224,7 @@
 
   In earlier releases of lacinia-pedestal, this logic was combined with [[query-parser-interceptor]].
 
-  Deprected: Use [[pedestal2/prepare-query-interceptor]] instead."
+  Deprecated: Use [[pedestal2/prepare-query-interceptor]] instead."
   (interceptor
     {:name ::prepare-query
      :enter internal/on-enter-prepare-query}))

--- a/src/com/walmartlabs/lacinia/pedestal/internal.clj
+++ b/src/com/walmartlabs/lacinia/pedestal/internal.clj
@@ -13,7 +13,7 @@
 ; limitations under the License.
 
 (ns ^:no-doc com.walmartlabs.lacinia.pedestal.internal
-  "Internal utilties not part of the public API."
+  "Internal utilities not part of the public API."
   (:require
     [clojure.core.async :refer [chan put!]]
     [cheshire.core :as cheshire]

--- a/src/com/walmartlabs/lacinia/pedestal/subscriptions.clj
+++ b/src/com/walmartlabs/lacinia/pedestal/subscriptions.clj
@@ -351,7 +351,7 @@
                  thread)
              (recur))
            (do
-              ;; The streamer has signalled that it has exhausted the subscription.
+              ;; The streamer has signaled that it has exhausted the subscription.
              (>! response-data-ch {:type :complete
                                    :id id})
              (close! response-data-ch)


### PR DESCRIPTION
I whipped through the lacinia-pedestal Overview doc this morning and found that it was slightly off since the `pedestal2` ns is different now.

I tried to bring things up to date as much as possible for a quick first pass, plus fixed a few typos and rst formatting issues.

I'd be happy to keep adding to this PR or file follow-ups since I'm sure there are parts that still don't quite work with the latest, I didn't run all the code examples in the docs.