### PR TITLE
Add support for request tracing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.15.0 -- UNRELEASED
+
+Requests for GraphQL IDE assets will now return a 304 Not Modified response when the client
+already has the current content.
+
+Support for [Lacinia request tracing](https://lacinia.readthedocs.io/en/latest/tracing.html) has been added; 
+it is enabled by default when using `com.walmartlabs.lacinia.pedestal2/default-service`.
+
 ## 0.14.0 -- 30 Jun 2020
 
 New `com.walmartlabs.lacinia.pedestal2` namespace de-complects

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -199,8 +199,7 @@ pseudoxml:
 
 live: clean html
 		$(SPHINXAUTOBUILD) \
-				-i '.git/*' \
-				-i 'meeting-notes/*' \
+				--ignore '.git/*' \
 				--no-initial \
 				--open-browser \
 				-b html \

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,7 +71,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'com.walmartlabs/lacinia-pedestal'
-copyright = u'2017, Walmartlabs'
+copyright = u'2017-2020, Walmartlabs'
 author = u'Lacinia Contributors'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,6 +21,7 @@ providing the `GraphIQL client <https://github.com/graphql/graphiql>`_
    async
    subscriptions
    interceptors
+   tracing
 
    API Documentation <http://walmartlabs.github.io/apidocs/lacinia-pedestal/>
    GitHub Project <https://github.com/walmartlabs/lacinia-pedestal>

--- a/docs/tracing.rst
+++ b/docs/tracing.rst
@@ -1,0 +1,13 @@
+Request Tracing
+=======
+
+Lacinia includes `support for request tracing <https://lacinia.readthedocs.io/en/latest/tracing.html>`_, which identifies
+how much time Lacinia spends parsing, validating, and processing the overall request.
+
+By default, this is enabled by passing the header value ``lacinia-tracing`` set to ``true`` (or any non-blank string).
+
+Further, the default is for the GraphiQL IDE to provide this value; queries using the IDE will trigger tracing behavior
+(often resulting in very, very large responses).
+
+You will typically want to disable tracing in production, by removing the ``:com.walmartlabs.lacinia.pedestal2/enable-tracing``
+:doc:`interceptor <interceptors>`.

--- a/project.clj
+++ b/project.clj
@@ -4,13 +4,13 @@
   :license {:name "Apache Software License 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
   :dependencies [[org.clojure/clojure "1.10.1"]
-                 [com.walmartlabs/lacinia "0.37.0"]
-                 [com.fasterxml.jackson.core/jackson-core "2.11.1"]
+                 [com.walmartlabs/lacinia "0.38.0-alpha-1"]
+                 [com.fasterxml.jackson.core/jackson-core "2.11.2"]
                  [io.pedestal/pedestal.service "0.5.8"]
                  [io.pedestal/pedestal.jetty "0.5.8"]
                  [org.clojure/data.json "1.0.0"]]
   :profiles
-  {:dev {:dependencies [[clj-http "3.10.1"]
+  {:dev {:dependencies [[clj-http "3.10.2"]
                         [com.walmartlabs/test-reporting "1.0.0"]
                         [com.stuartsierra/component "1.0.0"]
                         [expound "0.8.5"]

--- a/src/com/walmartlabs/lacinia/pedestal.clj
+++ b/src/com/walmartlabs/lacinia/pedestal.clj
@@ -93,18 +93,18 @@
                      :interceptor-name keyword?))
 
 (defmulti extract-query
-          "Based on the content type of the query, adds up to three keys to the request:
+  "Based on the content type of the query, adds up to three keys to the request:
 
-          :graphql-query
-          : The query itself, as a string (parsing the query happens later).
+  :graphql-query
+  : The query itself, as a string (parsing the query happens later).
 
-          :graphql-vars
-          : A map of variables used when executing the query.
+  :graphql-vars
+  : A map of variables used when executing the query.
 
-          :graphql-operation-name
-          : The specific operation requested (for queries that define multiple named operations)."
-          (fn [request]
-            (internal/content-type request)))
+  :graphql-operation-name
+  : The specific operation requested (for queries that define multiple named operations)."
+  (fn [request]
+    (internal/content-type request)))
 
 (defmethod extract-query :application/json [request]
   (let [body (cheshire/parse-string (:body request) true)
@@ -145,8 +145,8 @@
 
    Deprecated: Use [[pedestal2/error-response-interceptor]] instead."
   (interceptor
-   {:name ::error-response
-    :error internal/on-error-error-response}))
+    {:name ::error-response
+     :error internal/on-error-error-response}))
 
 (def ^{:deprecated "0.14.0"} body-data-interceptor
   "Converts the POSTed body from a input stream into a string.
@@ -168,10 +168,10 @@
                 (let [request (:request context)
                       q (extract-query request)]
                   (assoc context :request
-                                 (merge request q)))
+                         (merge request q)))
                 (catch Exception e
                   (assoc context :response
-                                 (internal/failure-response {:message (str "Invalid request: " (.getMessage e))})))))}))
+                         (internal/failure-response {:message (str "Invalid request: " (.getMessage e))})))))}))
 
 (defn ^:private query-not-found-error
   [request]
@@ -195,7 +195,7 @@
      :enter (fn [context]
               (if (-> context :request :graphql-query str/blank?)
                 (assoc context :response
-                               (internal/failure-response (query-not-found-error (:request context))))
+                       (internal/failure-response (query-not-found-error (:request context))))
                 context))}))
 
 (defn ^{:deprecated "0.14.0"} query-parser-interceptor
@@ -215,7 +215,8 @@
   [compiled-schema]
   (interceptor
     {:name ::query-parser
-     :enter (internal/on-enter-query-parser compiled-schema)}))
+     :enter (fn [context]
+              (internal/on-enter-query-parser context compiled-schema nil))}))
 
 (def ^{:added "0.10.0"
        :deprecated "0.14.0"} prepare-query-interceptor
@@ -249,8 +250,8 @@
 
   Deprecated: Use [[pedestal2/query-executor-handler]] instead."
   (interceptor
-   {:name  ::query-executor
-    :enter (internal/on-enter-query-executor ::query-executor)}))
+    {:name ::query-executor
+     :enter (internal/on-enter-query-executor ::query-executor)}))
 
 (def ^{:added "0.2.0"
        :deprecated "0.14.0"} async-query-executor-handler
@@ -329,8 +330,8 @@
         post-interceptors (into [body-data-interceptor] interceptors)]
     (cond-> #{[path :post post-interceptors
                :route-name ::graphql-post]}
-            get-enabled (conj [path :get interceptors
-                               :route-name ::graphql-get]))))
+      get-enabled (conj [path :get interceptors
+                         :route-name ::graphql-get]))))
 
 (defn graphiql-ide-response
   "Reads the graphiql.html resource, then injects new content into it, and ultimately returns a Ring
@@ -492,11 +493,11 @@
              ::http/type :jetty
              ::http/join? false}
 
-            subscriptions
-            (internal/add-subscriptions-support compiled-schema subscriptions-path options)
+      subscriptions
+      (internal/add-subscriptions-support compiled-schema subscriptions-path options)
 
-            graphiql
-            (assoc ::http/secure-headers nil))))
+      graphiql
+      (assoc ::http/secure-headers nil))))
 
 (s/fdef service-map
         :args (s/cat :compiled-schema ::spec/compiled-schema

--- a/src/com/walmartlabs/lacinia/pedestal2.clj
+++ b/src/com/walmartlabs/lacinia/pedestal2.clj
@@ -19,6 +19,7 @@
             [clojure.string :as str]
             [com.walmartlabs.lacinia.pedestal.interceptors :as interceptors]
             [com.walmartlabs.lacinia.pedestal.internal :as internal]
+            [com.walmartlabs.lacinia.tracing :as tracing]
             [io.pedestal.http :as http]
             [io.pedestal.interceptor :refer [interceptor]]
             [ring.middleware.not-modified :refer [wrap-not-modified]]
@@ -36,8 +37,8 @@
 
    This must come after [[json-response-interceptor]], as the error still needs to be converted to json."
   (interceptor
-   {:name ::error-response
-    :error internal/on-error-error-response}))
+    {:name ::error-response
+     :error internal/on-error-error-response}))
 
 (def body-data-interceptor
   "Converts the POSTed body from a input stream into a string, or rejects the request
@@ -71,8 +72,8 @@
                           :graphql-operation-name operation-name))
                 (catch Exception e
                   (assoc context :response
-                                 (internal/failure-response
-                                   {:message (str "Invalid request: " (.getMessage e))})))))}))
+                         (internal/failure-response
+                           {:message (str "Invalid request: " (.getMessage e))})))))}))
 
 (def missing-query-interceptor
   "Rejects the request with a 400 response is the JSON query variable is missing or blank.
@@ -83,7 +84,7 @@
      :enter (fn [context]
               (if (-> context :request :graphql-query str/blank?)
                 (assoc context :response
-                               (internal/failure-response "JSON 'query' key is missing or blank"))
+                       (internal/failure-response "JSON 'query' key is missing or blank"))
                 context))}))
 
 (defn query-parser-interceptor
@@ -101,7 +102,8 @@
   [compiled-schema]
   (interceptor
     {:name ::query-parser
-     :enter (internal/on-enter-query-parser compiled-schema)}))
+     :enter (fn [context]
+              (internal/on-enter-query-parser context compiled-schema (get-in context [:request ::timing-start])))}))
 
 (def prepare-query-interceptor
   "Prepares (with query variables) and validates the query, previously parsed
@@ -145,8 +147,8 @@
 
   This comes last in the interceptor chain."
   (interceptor
-   {:name  ::query-executor
-    :enter (internal/on-enter-query-executor ::query-executor)}))
+    {:name ::query-executor
+     :enter (internal/on-enter-query-executor ::query-executor)}))
 
 (def async-query-executor-handler
   "Async variant of [[query-executor-handler]] which returns a channel that conveys the
@@ -155,9 +157,29 @@
     {:name ::async-query-executor
      :enter (internal/on-enter-async-query-executor ::async-query-executor)}))
 
+(def ^{:added "0.15.0"} initialize-timing-interceptor
+  "Initializes timing information for the request; largely, this captures the earliest
+  possible start time for the request (before any other interceptors), just in case
+  traciing is enabled for this request."
+  (interceptor
+    {:name ::initialize-timing
+     :enter (fn [context]
+              (assoc-in context [:request ::timing-start] (tracing/create-timing-start)))}))
+
+(def ^{:added "0.15.0"} enable-tracing-interceptor
+  "Enables tracing if the `lacinia-tracing` header is present."
+  (interceptor
+    {:name ::enable-tracing
+     :enter (fn [context]
+              (let [request (:request context)
+                    enabled? (get-in request [:headers "lacinia-tracing"])]
+                (cond-> context
+                  enabled? (update-in [:request :lacinia-app-context] tracing/enable-tracing))))}))
+
 (defn default-interceptors
   "Returns the default set of GraphQL interceptors, as a seq:
 
+    * ::initialize-tracing [[initialize-timing-interceptor]]
     * ::json-response [[json-response-interceptor]]
     * ::error-response [[error-response-interceptor]]
     * ::body-data [[body-data-interceptor]]
@@ -168,6 +190,7 @@
     * ::disallow-subscriptions [[disallow-subscriptions-interceptor]]
     * ::prepare-query [[prepare-query-interceptor]]
     * ::inject-app-context [[inject-app-context-interceptor]]
+    * ::enable-tracing [[enable-tracing-interceptor]]
     * ::query-executor [[query-executor-handler]]
 
   `compiled-schema` may be the actual compiled schema, or a no-arguments function that returns the compiled schema.
@@ -177,7 +200,8 @@
 
   Often, this list of interceptors is augmented by calls to [[inject]]."
   [compiled-schema app-context]
-  [json-response-interceptor
+  [initialize-timing-interceptor
+   json-response-interceptor
    error-response-interceptor
    body-data-interceptor
    graphql-data-interceptor
@@ -187,6 +211,7 @@
    disallow-subscriptions-interceptor
    prepare-query-interceptor
    (inject-app-context-interceptor app-context)
+   enable-tracing-interceptor
    query-executor-handler])
 
 (defn graphiql-asset-routes
@@ -196,9 +221,9 @@
   [asset-path]
   (let [asset-path' (str asset-path "/*path")
         asset-get-handler (wrap-not-modified
-                           (fn [request]
-                             (response/resource-response (-> request :path-params :path)
-                                                         {:root "graphiql"})))
+                            (fn [request]
+                              (response/resource-response (-> request :path-params :path)
+                                                          {:root "graphiql"})))
         asset-head-handler #(-> %
                                 asset-get-handler
                                 (assoc :body nil))]
@@ -231,6 +256,9 @@
     These define additional headers to be included in the requests from the IDE.
     Typically, the headers are used to identify and authenticate the requests.
 
+    The default for :ide-headers is `{\"lacinia-tracing\", \"true\"} to enable GraphQL
+    tracing from inside the GraphiQL IDE>
+
   :ide-connection-params
   : A value that is used with the GraphiQL IDE; this value is converted to JSON,
     and becomes the connectionParams passed in the initial subscription web service call;
@@ -239,7 +267,8 @@
   (let [{:keys [api-path asset-path subscriptions-path ide-headers ide-connection-params]
          :or {api-path default-api-path
               asset-path default-asset-path
-              subscriptions-path default-subscriptions-path}} options
+              subscriptions-path default-subscriptions-path
+              ide-headers {"lacinia-tracing" "true"}}} options
         response (internal/graphiql-response
                    api-path subscriptions-path asset-path ide-headers ide-connection-params)]
     (fn [_]

--- a/test/com/walmartlabs/lacinia/pedestal2_test.clj
+++ b/test/com/walmartlabs/lacinia/pedestal2_test.clj
@@ -108,7 +108,7 @@
   (tu/expect-message {:type "connection_ack"}))
 
 
-(deftest can-return-timing-information
+(deftest can-provide-tracing-information
   (let [query "{ echo(value: \"hello\") { value method }}"
         response (send-request query {:headers {"lacinia-tracing" "true"}})]
     (reporting [response]


### PR DESCRIPTION
Because request tracing is somewhat expensive, it is optional, enabled by the `lacinia-tracing` request header; even so it should be disabled entirely in production.