### PR TITLE
adding the option to change the default host address used by pedestal

### DIFF
--- a/src/com/walmartlabs/lacinia/pedestal.clj
+++ b/src/com/walmartlabs/lacinia/pedestal.clj
@@ -37,6 +37,8 @@
 
 (def ^:private default-subscriptions-path "/graphql-ws")
 
+(def ^:private default-host-address "localhost")
+
 (defn inject
   "Locates the named interceptor in the list of interceptors and adds (or replaces)
   the new interceptor to the list.
@@ -460,6 +462,9 @@
   : If true, the query will execute asynchronously; the handler will return a clojure.core.async
     channel rather than blocking.
 
+  :host (default: localhost)
+  : HOST address bind to pedestal/jetty.
+
   :app-context
   : The base application context provided to Lacinia when executing a query.
 
@@ -479,17 +484,19 @@
   {:added "0.5.0"
    :deprecated "0.14.0"}
   [compiled-schema options]
-  (let [{:keys [graphiql subscriptions port env subscriptions-path]
+  (let [{:keys [graphiql subscriptions port env subscriptions-path host]
          :or {graphiql false
               subscriptions false
               port 8888
               subscriptions-path default-subscriptions-path
-              env :dev}} options
+              env :dev
+              host default-host-address}} options
         routes (or (:routes options)
                    (graphql-routes compiled-schema options))]
     (cond-> {:env env
              ::http/routes routes
              ::http/port port
+             ::http/host host
              ::http/type :jetty
              ::http/join? false}
 
@@ -517,7 +524,9 @@
                                               ::spec/app-context
                                               ::subscriptions-path
                                               ::port
-                                              ::env]))
+                                              ::env
+                                              ::host
+                                              ]))
 (s/def ::graphiql boolean?)
 (s/def ::routes some?)                                      ; Details are far too complicated
 (s/def ::subscriptions boolean?)
@@ -532,4 +541,4 @@
 (s/def ::subscriptions-path ::path)
 (s/def ::port nat-int?)
 (s/def ::env keyword?)
-
+(s/def ::host string?)

--- a/src/com/walmartlabs/lacinia/pedestal2.clj
+++ b/src/com/walmartlabs/lacinia/pedestal2.clj
@@ -238,6 +238,7 @@
 (def ^:private default-api-path "/api")
 (def ^:private default-asset-path "/assets/graphiql")
 (def ^:private default-subscriptions-path "/ws")
+(def ^:private default-host-address "localhost")
 
 (defn graphiql-ide-handler
   "Returns a handler for the GraphiQL IDE.
@@ -312,14 +313,17 @@
 
   It may also contain keys :app-context and :port (which defaults to 8888).
 
+  You can also define an explicit :host address to your application. Useful when running inside Docker.
+
   This is useful for initial development and exploration, but applications with any more needs should construct
   their service map directly."
   [compiled-schema options]
-  (let [{:keys [api-path ide-path asset-path app-context port]
+  (let [{:keys [api-path ide-path asset-path app-context port host]
          :or {api-path default-api-path
               ide-path "/ide"
               asset-path default-asset-path
-              port 8888}} options
+              port 8888
+              host default-host-address}} options
         interceptors (default-interceptors compiled-schema app-context)
         routes (into #{[api-path :post interceptors :route-name ::graphql-api]
                        [ide-path :get (graphiql-ide-handler options) :route-name ::graphiql-ide]}
@@ -327,6 +331,7 @@
     (-> {:env :dev
          ::http/routes routes
          ::http/port port
+         ::http/host host
          ::http/type :jetty
          ::http/join? false}
         enable-graphiql


### PR DESCRIPTION
Hello @hlship , thanks for the great library.

My current projects run inside a `docker` container and I faced an issue with an upstream change in pedestal (https://github.com/pedestal/pedestal/issues/604). I noticed that I was not able to pass forward the necessary parameter to apply the fix to my current setup.

The PR contains the necessary extension to keep the library compatible with pedestal standard (default to localhost) but provides the user the ability to change it.

Thanks.