### PR TITLE
Subscriptions: Decrease default ka timeout to be less than jettys ws timeout

### DIFF
--- a/src/com/walmartlabs/lacinia/pedestal/subscriptions.clj
+++ b/src/com/walmartlabs/lacinia/pedestal/subscriptions.clj
@@ -470,8 +470,10 @@
 
   Options:
 
-  :keep-alive-ms (default: 30000)
+  :keep-alive-ms (default: 25000)
   : The interval at which keep alive messages are sent to the client.
+    Note that configuring this timeout to be at or above 30s conflicts with a default Jetty timeout
+    closing websockets after 30s of idle time.
 
   :app-context
   : The base application context provided to Lacinia when executing a query.
@@ -502,7 +504,7 @@
     channel)."
   [compiled-schema options]
   (let [{:keys [keep-alive-ms app-context init-context send-buffer-or-n response-chan-fn values-chan-fn]
-         :or {keep-alive-ms 30000
+         :or {keep-alive-ms 25000
               send-buffer-or-n 10
               response-chan-fn #(chan 10)
               values-chan-fn #(chan 1)


### PR DESCRIPTION
lacinia-pedestal will send a keep alive every 30s, but Jetty also expects a message being sent every 30s. This causes a race, sometimes the go-loop sending the keep alives is fast enough, satisfying Jetty, sometimes Jetty closes the socket just before this keep alive is sent.

Therefore the default keep alive timeout is set to 25s, and a warning is added to the docstring that values at-or-over 30s can cause issues.

-----

Alternatively I've considered configuring Jetty's timeout based on the keep alive timeout, for example by doubling it. But this seems unsupported by pedestal's jetty integration layer.