### PR TITLE
Support ResolverResult passed to subscription stream callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
-## 1.0 - 9 Oct 2021
+## 1.1 -- UNRELEASED
+
+A subtle bug in subscriptions was fixed; a streamer that passes nil to
+the source stream callback could prevent any values currently being rendered
+from being sent back to the client; this is related to
+a Lacinia 1.1 PR.
+
+[Closed Issues](https://github.com/walmartlabs/lacinia-pedestal/milestone/18?closed=1)
+
+## 1.0 -- 9 Oct 2021
 
 [Closed Issues](https://github.com/walmartlabs/lacinia-pedestal/milestone/17?closed=1)
 
@@ -10,7 +19,7 @@ with the query and query variables.
 
 [Closed Issues](https://github.com/walmartlabs/lacinia-pedestal/milestone/16?closed=1)
 
-## 0.16 - 18 Jun 2021
+## 0.16 -- 18 Jun 2021
 
 Updated the version of the packaged GraphiQL.
 

--- a/README.md
+++ b/README.md
@@ -30,18 +30,19 @@ generate a service, then invoke `io.pedestal.http/create-server` and `/start`.
             [com.walmartlabs.lacinia.schema :as schema]))
 
 (def hello-schema 
-(schema/compile
-  {:queries 
-    {:hello
-      ;; String is quoted here; in EDN the quotation is not required
-      {:type 'String
-       :resolve (constantly "world")}}}))
+  (schema/compile
+    {:queries 
+      {:hello
+        ;; String is quoted here; in EDN the quotation is not required 
+        ;; You could also use :String
+        {:type 'String
+         :resolve (constantly "world")}}}))
 
 ;; Use default options:
 (def service (lp/default-service hello-schema nil))
 
-;; This is an adapted service map, that can be started and stopped
-;; From the REPL you can call server/start and server/stop on this service
+;; This is an adapted service map, that can be started and stopped.
+;; From the REPL you can call http/start and http/stop on this service:
 (defonce runnable-service (http/create-server service))
 
 (defn -main
@@ -82,7 +83,7 @@ using the building-blocks provided by `com.walmartlabs.lacinia.pedestal2`.
 ### GraphiQL
 
 The GraphiQL packaged inside the library is built using `npm`, from
-version `1.4.2`.
+version `1.4.7`.
 
 ## License
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,5 @@
 {:deps {org.clojure/clojure {:mvn/version "1.10.3"}
-        ;com.walmartlabs/lacinia {:mvn/version "1.0"}
-        com.walmartlabs/lacinia {:local/root "../lacinia"}
+        com.walmartlabs/lacinia {:mvn/version "1.1-alpha-6"}
         com.fasterxml.jackson.core/jackson-core {:mvn/version "2.12.3"}
         io.pedestal/pedestal.service {:mvn/version "0.5.8"}
         io.pedestal/pedestal.jetty {:mvn/version "0.5.8"}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,36 @@
+{:deps {org.clojure/clojure {:mvn/version "1.10.3"}
+        com.walmartlabs/lacinia {:mvn/version "1.0"}
+        com.fasterxml.jackson.core/jackson-core {:mvn/version "2.12.3"}
+        io.pedestal/pedestal.service {:mvn/version "0.5.8"}
+        io.pedestal/pedestal.jetty {:mvn/version "0.5.8"}}
+ :paths ["src" "resources"]
+ :aliases
+ {:dev
+  {:extra-deps {clj-http/clj-http {:mvn/version "3.12.3"}
+                com.walmartlabs/test-reporting {:mvn/version "1.1"}
+                com.stuartsierra/component {:mvn/version "1.0.0"}
+                expound/expound {:mvn/version "0.8.10"}
+                stylefruits/gniazdo {:mvn/version "1.2.0"
+                                     :exclusions [org.eclipse.jetty.websocket/websocket-client]}
+                io.aviso/logging {:mvn/version "1.0"}}
+
+   :jvm-opts ["-Xmx500m"]
+   :extra-paths ["test" "dev-resources"]}
+
+  ;; :test needs :dev, i.e. clj -Xdev:test
+  :test
+  {:extra-deps {io.github.cognitect-labs/test-runner
+                {:git/url "https://github.com/cognitect-labs/test-runner.git"
+                 :sha "705ad25bbf0228b1c38d0244a36001c2987d7337"}}
+   :exec-fn cognitect.test-runner.api/test
+   :exec-args
+   {:patterns [".*-tests?$"]}}
+
+  ;; clj -Xdev:codox
+  :codox
+  {:extra-deps {codox/codox {:mvn/version "0.10.7"}}
+   :exec-fn codox.main/generate-docs
+   :exec-args {:metadata {:doc/format :markdown}
+               :name "com.walmartlabs/lacinia-pedestal"
+               :version "1.1+"
+               :description "Clojure-native implementation of GraphQL"}}}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,6 @@
 {:deps {org.clojure/clojure {:mvn/version "1.10.3"}
-        com.walmartlabs/lacinia {:mvn/version "1.0"}
+        ;com.walmartlabs/lacinia {:mvn/version "1.0"}
+        com.walmartlabs/lacinia {:local/root "../lacinia"}
         com.fasterxml.jackson.core/jackson-core {:mvn/version "2.12.3"}
         io.pedestal/pedestal.service {:mvn/version "0.5.8"}
         io.pedestal/pedestal.jetty {:mvn/version "0.5.8"}}

--- a/dev-resources/com/walmartlabs/lacinia/test_utils.clj
+++ b/dev-resources/com/walmartlabs/lacinia/test_utils.clj
@@ -13,7 +13,8 @@
     [com.walmartlabs.lacinia.resolve :refer [resolve-as]]
     [gniazdo.core :as g]
     [io.pedestal.log :as log]
-    [cheshire.core :as cheshire]))
+    [cheshire.core :as cheshire]
+    [com.walmartlabs.lacinia.resolve :as resolve]))
 
 (def *echo-context (atom nil))
 
@@ -38,10 +39,12 @@
   (reset! *ping-context context)
   (let [{:keys [message count]} args
         runnable ^Runnable (fn []
-                             (dotimes [i count]
-                               (source-stream {:message (str message " #" (inc i))
-                                               :timestamp (System/currentTimeMillis)})
-                               (Thread/sleep 50))
+                             (if (< count 1)
+                               (source-stream (resolve/resolve-as nil {:message "count must be at least 1"}))
+                               (dotimes [i count]
+                                 (source-stream {:message (str message " #" (inc i))
+                                                 :timestamp (System/currentTimeMillis)})
+                                 (Thread/sleep 50)))
 
                              (source-stream nil))]
     (.start (Thread. runnable "stream-ping-thread")))

--- a/project.clj
+++ b/project.clj
@@ -7,8 +7,7 @@
                  [com.walmartlabs/lacinia "1.0"]
                  [com.fasterxml.jackson.core/jackson-core "2.12.3"]
                  [io.pedestal/pedestal.service "0.5.8"]
-                 [io.pedestal/pedestal.jetty "0.5.8"]
-                 [org.clojure/data.json "2.3.1"]]
+                 [io.pedestal/pedestal.jetty "0.5.8"]]
   :profiles
   {:dev {:dependencies [[clj-http "3.12.3"]
                         [com.walmartlabs/test-reporting "1.1"]

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Apache Software License 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
   :dependencies [[org.clojure/clojure "1.10.3"]
-                 [com.walmartlabs/lacinia "1.0"]
+                 [com.walmartlabs/lacinia "1.1-alpha-6"]
                  [com.fasterxml.jackson.core/jackson-core "2.12.3"]
                  [io.pedestal/pedestal.service "0.5.8"]
                  [io.pedestal/pedestal.jetty "0.5.8"]]


### PR DESCRIPTION
In Lacinia 1.0, a ResolverResult was handled inside lacinia proper, even though this was not documented; in Lacinia 1.1, this is no longer supported directly, and implementations of subscriptions are responsible.

In addition, in testing, I found a bug where a subscription that passes a value to the callback, then immediately passes a nil, prevents the value from being executed and streamed to the client before the connection is closed; this is fixed, ensuring that all currently executing queries complete and stream before the connection is closed.