### PR TITLE
Add repository info to pom.xml

### DIFF
--- a/build.clj
+++ b/build.clj
@@ -58,6 +58,11 @@
                   :lib lib
                   :version version
                   :basis basis
+                  :src-pom "templates/pom.xml"
+                  :scm {:url "https://github.com/walmartlabs/lacinia-pedestal"
+                        :connection "scm:git:git://github.com/walmartlabs/lacinia-pedestal.git"
+                        :developerConnection "scm:git:ssh://git@github.com/walmartlabs/lacinia-pedestal.git"
+                        :tag version}
                   :src-dirs ["src"]
                   :resource-dirs ["resources"]})
     (b/copy-dir {:src-dirs copy-srcs

--- a/templates/pom.xml
+++ b/templates/pom.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <packaging>jar</packaging>
+    <groupId>com.walmartlabs</groupId>
+    <artifactId>lacinia-pedestal</artifactId>
+    <url>https://github.com/walmartlabs/lacinia-pedestal</url>
+    <description>Expose Lacinia GraphQL as Pedestal endpoints</description>
+</project>


### PR DESCRIPTION
Add `url` and `scm` tags to final `pom` / `jar` file.

It allow developer tools, like IDE's, cljdoc, mvnrepository, to browse from the artifact to the repository.