### PR TITLE
docs(readme): add `(schema/compile)` to `hello-schema`

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ generate a service, then invoke `io.pedestal.http/create-server` and `/start`.
             ;; String is quoted here; in EDN the quotation is not required 
             ;; You could also use :String
             {:hello {:type 'String}}}}}
-       (util/inject-resolvers {:Query/hello (constantly "hello")})))
+       (util/inject-resolvers {:Query/hello (constantly "hello")})
+       (schema/compile)))
 
 ;; Use default options:
 (def service (lp/default-service hello-schema nil))


### PR DESCRIPTION
When I copied the usage guide and ran `lein run`, I got the following error response when executing the example curl request from the readme:

```{"errors":[{"message":"The provided schema has not been compiled."}]}```

WIth the extra `(schema/compile)` step it works as expected

---

Signed-off-by: Jan-Gerke Salomon [jgs.salomon@gmail.com](mailto:jgs.salomon@gmail.com)