### PR TITLE
base-context initialization

### DIFF
--- a/src/com/walmartlabs/lacinia/pedestal/internal.clj
+++ b/src/com/walmartlabs/lacinia/pedestal/internal.clj
@@ -431,9 +431,17 @@
                (when (>! response-data-ch {:type :connection_ack})
                  (recur (assoc connection-state :connection-params payload)))
 
+               ;; graphql-transport-ws keep-alive: the client may send a "ping" at any time,
+               ;; and the server must reply with a "pong".
+               "ping"
+               (when (>! response-data-ch {:type :pong})
+                 (recur connection-state))
+
                ;; TODO: Track state, don't allow start, etc. until after connection_init
 
-               "start"
+               ;; "start" is the legacy graphql-ws verb; "subscribe" is its graphql-transport-ws
+               ;; equivalent.
+               ("start" "subscribe")
                (if (contains? (:subs connection-state) id)
                  (do
                    (log/trace :event ::ignoring-duplicate :id id)
@@ -444,7 +452,9 @@
                          sub-shutdown-ch (execute-query-interceptors id payload response-data-ch cleanup-ch merged-context)]
                      (recur (assoc-in connection-state [:subs id] sub-shutdown-ch)))))
 
-               "stop"
+               ;; "stop" is the legacy graphql-ws verb; "complete" is its graphql-transport-ws
+               ;; equivalent.
+               ("stop" "complete")
                (do
                  (log/trace :event ::stop :id id)
                  (when-some [sub-shutdown-ch (get-in connection-state [:subs id])]
@@ -538,11 +548,25 @@
                             :payload payload})
     (close! response-data-ch)))
 
+(defn protocol-response-type
+  "Returns the message :type to use when delivering query/subscription payloads to the
+  client, based on the negotiated WebSocket subprotocol stored in the context under
+  ::subprotocol.
+
+  The modern graphql-transport-ws protocol (used by GraphiQL and current Apollo clients)
+  expects \"next\" messages, while the legacy graphql-ws (subscriptions-transport-ws)
+  protocol expects \"data\" messages. Defaults to :data when the subprotocol is unknown,
+  preserving legacy behaviour."
+  [context]
+  (case (::subprotocol context)
+    "graphql-transport-ws" :next
+    :data))
+
 (defn leave-send-operation-response
   [context]
   (when-let [response (:response context)]
     (let [{:keys [id response-data-ch]} (:request context)]
-      (put! response-data-ch {:type    :data
+      (put! response-data-ch {:type    (protocol-response-type context)
                               :id      id
                               :payload response})
       (put! response-data-ch {:type :complete
@@ -590,6 +614,7 @@
 (defn ^:private execute-subscription
   [context parsed-query]
   (let [{:keys [::values-chan-fn request]} context
+        response-type        (protocol-response-type context)
         source-stream-ch     (values-chan-fn)
         {:keys [id shutdown-ch response-data-ch]} request
         source-stream        (fn accept-value [value]
@@ -643,7 +668,7 @@
                  (resolve/on-deliver! (fn [response]
                                         (log/trace :response response :id id)
                                         (put! response-data-ch
-                                              {:type    :data
+                                              {:type    response-type
                                                :id      id
                                                :payload response})
                                         (let [new-count (swap! *execution-count dec)]

--- a/src/com/walmartlabs/lacinia/pedestal/subscriptions.clj
+++ b/src/com/walmartlabs/lacinia/pedestal/subscriptions.clj
@@ -148,6 +148,15 @@
 
   :session-initializer Passed the jakarta.websocket.Session to perform any additional initialization.
 
+  :context-initializer
+  : An optional function `(fn [context session] -> context)` invoked once per WebSocket
+    connection, at open time. It receives the base subscription context and the
+    jakarta.websocket.Session for the handshake, and the returned context becomes the
+    per-connection context (carried into every operation on the connection). This is the
+    hook for establishing connection-scoped state -- for example, authenticating the
+    handshake (URL token, headers) and attaching the resulting principal so downstream
+    resolvers can authorize.
+
   :keep-alive-ms (default: 25000)
   : The interval at which keep alive messages are sent to the client.
     Note that configuring this timeout to be at or above 30s conflicts with a default Jetty timeout
@@ -173,7 +182,8 @@
   : Used to create the channel of text responses sent to the client. The default is 10 (a non-lossy
     channel)."
   [compiled-schema options]
-  (let [{:keys [keep-alive-ms app-context send-buffer-or-n response-chan-fn values-chan-fn session-initializer]
+  (let [{:keys [keep-alive-ms app-context send-buffer-or-n response-chan-fn values-chan-fn session-initializer
+                context-initializer]
          :or {keep-alive-ms 25000
               send-buffer-or-n 10
               response-chan-fn #(chan 10)
@@ -195,10 +205,17 @@
                         ; client text -> server
                         ws-text-ch (chan 1)
                         ; client text -> client data
-                        ws-data-ch (chan 10)]
+                        ws-data-ch (chan 10)
+                        ;; Build the per-connection context: let the application initialize it from
+                        ;; the handshake Session (authentication, etc.), and record the negotiated
+                        ;; subprotocol -- authoritative here, straight from the container -- so
+                        ;; responses use the right message type ("next" vs. legacy "data").
+                        context (cond-> base-context
+                                  (fn? context-initializer) (context-initializer session)
+                                  :always (assoc ::internal/subprotocol (.getNegotiatedSubprotocol session)))]
                     (internal/response-encode-loop response-data-ch send-ch)
                     (internal/ws-parse-loop session-id ws-text-ch ws-data-ch response-data-ch)
-                    (internal/connection-loop session-id keep-alive-ms ws-data-ch response-data-ch base-context)
+                    (internal/connection-loop session-id keep-alive-ms ws-data-ch response-data-ch context)
                     {:response-data-ch response-data-ch
                      :ws-text-ch ws-text-ch
                      :ws-data-ch ws-data-ch
@@ -213,7 +230,7 @@
                    (log/error :event ::error :session-id session-id :exception t))]
     (-> options
         (select-keys [:idle-timeout-ms])
-        (assoc :subprotocols ["graphql-ws"]
+        (assoc :subprotocols ["graphql-transport-ws" "graphql-ws"]
                :on-open on-open
                :on-close on-close
                :on-text on-text
@@ -227,11 +244,13 @@
                                                       ::spec/app-context
                                                       ::subscription-interceptors
                                                       ::init-context
+                                                      ::context-initializer
                                                       ::response-ch-fn
                                                       ::values-chan-fn
                                                       ::send-buffer-or-n]))
 
 (s/def ::keep-alive-ms pos-int?)
+(s/def ::context-initializer fn?)
 (s/def ::subscription-interceptors ::spec/interceptors)
 (s/def ::init-context fn?)
 (s/def ::response-chan-fn fn?)

--- a/src/com/walmartlabs/lacinia/pedestal/subscriptions2.clj
+++ b/src/com/walmartlabs/lacinia/pedestal/subscriptions2.clj
@@ -21,6 +21,7 @@
             [io.pedestal.interceptor :refer [interceptor]]
             [io.pedestal.interceptor.chain :as chain]
             [io.pedestal.log :as log]
+            [clojure.string :as string]
             [clojure.spec.alpha :as s]
             [io.pedestal.service.websocket :as websocket]
             [com.walmartlabs.lacinia.pedestal.spec :as spec]
@@ -30,8 +31,8 @@
 (def exception-handler-interceptor
   "An interceptor that implements the :error callback, to send an \"error\" message to the client."
   (interceptor
-    {:name  ::exception-handler
-     :error internal/error-exception-handler}))
+   {:name  ::exception-handler
+    :error internal/error-exception-handler}))
 
 (def send-operation-response-interceptor
   "Interceptor responsible for the :response key of the context (set when a request
@@ -39,8 +40,8 @@
   is packaged up as the payload of a \"data\" message to the client,
   followed by a \"complete\" message."
   (interceptor
-    {:name  ::send-operation-response
-     :leave internal/leave-send-operation-response}))
+   {:name  ::send-operation-response
+    :leave internal/leave-send-operation-response}))
 
 (defn query-parser-interceptor
   "An interceptor that parses the query and places a prepared and validated
@@ -52,17 +53,17 @@
   that returns the compiled schema."
   [compiled-schema]
   (interceptor
-    {:name  ::query-parser
-     :enter (internal/enter-subscription-query-parser compiled-schema)
-     :leave internal/on-leave-query-parser
-     :error internal/on-error-query-parser}))
+   {:name  ::query-parser
+    :enter (internal/enter-subscription-query-parser compiled-schema)
+    :leave internal/on-leave-query-parser
+    :error internal/on-error-query-parser}))
 
 (def execute-operation-interceptor
   "Executes a mutation or query operation and sets the :response key of the context,
   or executes a long-lived subscription operation."
   (interceptor
-    {:name  ::execute-operation
-     :enter internal/enter-execute-operation}))
+   {:name  ::execute-operation
+    :enter internal/enter-execute-operation}))
 
 (defn inject-app-context-interceptor
   "Adds a :lacinia-app-context key to the request, used when executing the query.
@@ -77,10 +78,10 @@
   {:added "0.14.0"}
   [app-context]
   (interceptor
-    {:name  ::inject-app-context
-     :enter (interceptors/on-enter-app-context-interceptor app-context)
-     :leave interceptors/on-leave-app-context-interceptor
-     :error interceptors/on-error-app-context-interceptor}))
+   {:name  ::inject-app-context
+    :enter (interceptors/on-enter-app-context-interceptor app-context)
+    :leave interceptors/on-leave-app-context-interceptor
+    :error interceptors/on-error-app-context-interceptor}))
 
 (defn default-subscription-interceptors
   "Processing of operation requests from the client is passed through interceptor pipeline.
@@ -119,6 +120,26 @@
    (query-parser-interceptor compiled-schema)
    (inject-app-context-interceptor app-context)
    execute-operation-interceptor])
+
+(def ^:private supported-subprotocols
+  "The WebSocket subprotocols this endpoint advertises, in server-preference order
+  (the connector negotiates the first entry the client also supports).
+
+  \"graphql-transport-ws\" is the modern protocol (GraphiQL, current Apollo clients);
+  \"graphql-ws\" is the legacy subscriptions-transport-ws protocol."
+  ["graphql-transport-ws" "graphql-ws"])
+
+(defn ^:private negotiated-subprotocol
+  "Reproduces the connector's subprotocol negotiation from the upgrade request: returns the
+  first of `advertised` that the client also offered (via the Sec-WebSocket-Protocol request
+  header), or nil. The connector does not expose the negotiated value to application code, but
+  it negotiates by the same rule, so this yields the same result."
+  [request advertised]
+  (let [offered (some-> (get-in request [:headers "sec-websocket-protocol"])
+                        (string/split #"\s*,\s*")
+                        set)]
+    (when (seq offered)
+      (first (filter offered advertised)))))
 
 (defn subscription-interceptor
   "Returns an interceptor that upgrades an incoming HTTP request to a websocket connection, as
@@ -163,9 +184,18 @@
 
   :send-buffer-or-n
   : Used to create the channel of text responses sent to the client. The default is 10 (a non-lossy
-    channel)."
+    channel).
+
+  :context-initializer
+  : An optional function `(fn [context request] -> context)` invoked once per WebSocket
+    connection, at open time. It receives the base subscription context and the original
+    upgrade request map. The upgrade request has already passed through the Pedestal
+    interceptor chain, so it carries whatever upstream authentication/authorization
+    interceptors attached to it (the authenticated principal, a verified token's claims,
+    etc.). The returned context becomes the per-connection context."
   [compiled-schema options]
-  (let [{:keys [keep-alive-ms app-context send-buffer-or-n response-chan-fn values-chan-fn]
+  (let [{:keys [keep-alive-ms app-context send-buffer-or-n response-chan-fn values-chan-fn
+                context-initializer]
          :or   {keep-alive-ms    25000
                 send-buffer-or-n 10
                 response-chan-fn #(chan 10)
@@ -175,7 +205,7 @@
         base-context (-> {::internal/values-chan-fn values-chan-fn}
                          (chain/terminate-when :response)
                          (chain/enqueue interceptors))
-        on-open      (fn [^WebSocketChannel channel _request]
+        on-open      (fn [^WebSocketChannel channel request]
                        ;; TODO: parameter to generate session id
                        (let [session-id       (str (random-uuid))
                              _                (log/trace :event ::connected :id session-id)
@@ -185,10 +215,20 @@
                              ; client text -> server
                              ws-text-ch       (chan 1)
                              ; client text -> client data
-                             ws-data-ch       (chan 10)]
+                             ws-data-ch       (chan 10)
+                             ;; Build the per-connection context: let the application inject
+                             ;; authenticated identity (etc.) from the upgrade request, and record
+                             ;; the negotiated subprotocol so responses use the right message type.
+                             context          (cond-> base-context
+                                                (fn? context-initializer)
+                                                (context-initializer request)
+
+                                                :always
+                                                (assoc ::internal/subprotocol
+                                                       (negotiated-subprotocol request supported-subprotocols)))]
                          (internal/response-encode-loop response-data-ch send-ch)
                          (internal/ws-parse-loop session-id ws-text-ch ws-data-ch response-data-ch)
-                         (internal/connection-loop session-id keep-alive-ms ws-data-ch response-data-ch base-context)
+                         (internal/connection-loop session-id keep-alive-ms ws-data-ch response-data-ch context)
                          {:response-data-ch response-data-ch
                           :ws-text-ch       ws-text-ch
                           :ws-data-ch       ws-data-ch
@@ -199,27 +239,29 @@
                        (log/trace :event ::closed :reason reason :session-id session-id)
                        (close! response-data-ch)
                        (close! ws-data-ch))
-        ws-opts      {:subprotocols ["graphql-ws"]
+        ws-opts      {:subprotocols supported-subprotocols
                       :on-open      on-open
                       :on-close     on-close
                       :on-text      on-text}]
     (interceptor
-      {:name  ::subscription-websocket
-       :enter (fn [context]
-                (websocket/upgrade-request-to-websocket context ws-opts))})))
+     {:name  ::subscription-websocket
+      :enter (fn [context]
+               (websocket/upgrade-request-to-websocket context ws-opts))})))
 
 (s/fdef subscription-interceptor
-        :args (s/cat :compiled-schema ::spec/compiled-schema
-                     :options (s/nilable ::listener-fn-factory-options)))
+  :args (s/cat :compiled-schema ::spec/compiled-schema
+               :options (s/nilable ::listener-fn-factory-options)))
 
 (s/def ::listener-fn-factory-options (s/keys :opt-un [::keep-alive-ms
                                                       ::spec/app-context
                                                       ::subscription-interceptors
                                                       ::response-ch-fn
                                                       ::values-chan-fn
-                                                      ::send-buffer-or-n]))
+                                                      ::send-buffer-or-n
+                                                      ::context-initializer]))
 
 (s/def ::keep-alive-ms pos-int?)
+(s/def ::context-initializer fn?)
 (s/def ::subscription-interceptors ::spec/interceptors)
 (s/def ::response-chan-fn fn?)
 (s/def ::values-chan-fn fn?)

--- a/test/com/walmartlabs/lacinia/pedestal/graphql_ws_test.clj
+++ b/test/com/walmartlabs/lacinia/pedestal/graphql_ws_test.clj
@@ -13,14 +13,13 @@
 ; limitations under the License.
 
 (ns com.walmartlabs.lacinia.pedestal.graphql-ws-test
-  "Tests for graphql-transport-ws protocol support and the :context-initializer hook in
-  subscriptions2 (the pedestal3 connector path).
+  "graphql-transport-ws protocol support and the :context-initializer hook for subscriptions2.
 
-  Kept in its own namespace so the upstream pedestal3-test fixture and tests stay untouched:
-  this namespace stands up its own subscription server (on a separate port) wired with a
-  :context-initializer, and opens raw WebSocket connections so it can control the negotiated
-  subprotocol and the upgrade-request headers."
+  Runs its own subscription server on a separate port so the upstream pedestal3-test fixture
+  stays untouched, and opens raw WebSocket connections to control the subprotocol, headers, and
+  query string of the upgrade."
   (:require [clojure.test :refer [deftest is use-fixtures]]
+            [com.walmartlabs.lacinia :as lacinia]
             [com.walmartlabs.lacinia.pedestal.subscriptions2 :as subscriptions2]
             [com.walmartlabs.lacinia.test-utils :as tu
              :refer [*ping-context *echo-context *session*
@@ -32,54 +31,58 @@
             [hato.websocket :as ws]
             [clojure.core.async :refer [chan put!]]
             [io.pedestal.log :as log]
-            [com.walmartlabs.test-reporting :refer [reporting]]
             [io.pedestal.connector :as conn]))
 
-;; Own port, so this server coexists with the upstream pedestal3-test server (8888).
-(def port 8889)
-
+(def port 8889)                         ; coexists with pedestal3-test on 8888
 (def ws-url (str "ws://localhost:" port "/ws"))
 
-;; ---------------------------------------------------------------------------
-;; User-context wiring for the subscription endpoint.
-;;
-;; This demonstrates the intended use of :context-initializer: authenticate the
-;; WebSocket upgrade once, stash the resulting principal on the per-connection
-;; context, and -- via a small user-land interceptor -- make it visible to every
-;; query and subscription resolver on that connection. The library stays free of
-;; any "user context" opinion; the bridge lives entirely in application code.
+;; --- Authentication ---------------------------------------------------------
+;; A :context-initializer reads a credential off the upgrade request and stashes the resulting
+;; principal on the connection; an interceptor then merges it into every resolver's app-context.
+;; The library has no opinion about "user context" -- this is all application code.
 
 (def ^:private auth-header "authorization")
 
-(defn ^:private authenticate
-  "Stand-in authentication: resolves the upgrade request to a principal map, or nil when the
-  request carries no recognized credentials (an anonymous connection)."
-  [request]
-  (case (get-in request [:headers auth-header])
+(defn ^:private principal-for-token
+  "Maps a bearer token to a principal, or nil if unrecognized."
+  [token]
+  (case token
     "token-alice" {:user "alice" :roles #{:admin}}
     "token-bob"   {:user "bob"   :roles #{:viewer}}
     nil))
 
+(defn ^:private request-token
+  "Bearer token from the upgrade request: the Authorization header (non-browser clients) or an
+  ?access_token=… query param (the channel browsers use, as they cannot set headers)."
+  [request]
+  (or (get-in request [:headers auth-header])
+      (some->> (:query-string request)
+               (re-find #"(?:^|&)access_token=([^&]+)")
+               second)))
+
+(defn ^:private authenticate
+  "Resolves an upgrade request to a principal, or nil for an anonymous connection."
+  [request]
+  (principal-for-token (request-token request)))
+
 (def ^:private principal-key ::principal)
 
-(defn ^:private inject-app-context+principal-interceptor
-  "Like the library's app-context injector, but also merges the connection-scoped principal
-  (placed on the context by the :context-initializer) into the resolver app-context. This is
-  the user-land bridge that carries the authenticated user into every resolver. A nil principal
-  (anonymous connection) merges to nothing."
-  [app-context]
+(defn ^:private inject-principal-interceptor
+  "The app-context injector, additionally exposing the connection's principal to resolvers. The
+  principal comes from the handshake (:context-initializer) or, failing that, from a token in the
+  connection_init payload — the fallback browser clients rely on, since :context-initializer runs
+  before that payload arrives. A nil (anonymous) principal merges to nothing."
+  []
   (interceptor
-    {:name  ::inject-app-context+principal
+    {:name  ::inject-principal
      :enter (fn [context]
-              (assoc-in context [:request :lacinia-app-context]
-                        (-> (or app-context {})
-                            (assoc :request (:request context))
-                            (merge (get context principal-key)))))}))
+              (let [principal (or (get context principal-key)
+                                  (principal-for-token (:authToken (:connection-params context))))]
+                (assoc-in context [:request :lacinia-app-context]
+                          (merge {:request (:request context)} principal))))}))
 
-(defn ^:private user-context-subscription-interceptor
-  "Builds the subscription interceptor used by the test server: a :context-initializer that
-  authenticates the upgrade request, plus a custom interceptor chain (identical to the library
-  default except that it swaps in [[inject-app-context+principal-interceptor]])."
+(defn ^:private auth-subscription-interceptor
+  "subscriptions2 endpoint that authenticates the upgrade and exposes the principal to resolvers."
   [schema]
   (subscriptions2/subscription-interceptor
     schema
@@ -90,199 +93,172 @@
      [subscriptions2/exception-handler-interceptor
       subscriptions2/send-operation-response-interceptor
       (subscriptions2/query-parser-interceptor schema)
-      (inject-app-context+principal-interceptor nil)
+      (inject-principal-interceptor)
       subscriptions2/execute-operation-interceptor]}))
 
 (defn server-fixture
   [f]
-  (let [schema              (tu/compile-schema)
-        subscription-routes (table/table-routes
-                              [["/ws" :get (user-context-subscription-interceptor schema)
-                                :route-name ::subscriptions]])
-        connector           (-> (conn/default-connector-map port)
-                                (conn/with-routes subscription-routes)
-                                (jetty/create-connector nil)
-                                (conn/start!))]
+  (let [routes    (table/table-routes
+                    [["/ws" :get (auth-subscription-interceptor (tu/compile-schema))
+                      :route-name ::subscriptions]])
+        connector (-> (conn/default-connector-map port)
+                      (conn/with-routes routes)
+                      (jetty/create-connector nil)
+                      (conn/start!))]
     (try
       (f)
-      (finally
-        (conn/stop! connector)))))
+      (finally (conn/stop! connector)))))
 
 (use-fixtures :once server-fixture)
 
-;; ---------------------------------------------------------------------------
-;; Raw WebSocket helpers.
-;;
-;; These open their own connections so the tests can control the negotiated subprotocol
-;; and the upgrade-request headers, then rebind the test-utils dynamic vars so the existing
-;; send-*/<message!! helpers can be reused.
+;; --- WebSocket helpers ------------------------------------------------------
 
 (defn open-connection
-  "Opens a raw WebSocket connection to the subscription endpoint and returns a map of
-  {:session, :messages-ch}. `opts` may include :subprotocols and :headers."
-  [{:keys [subprotocols headers]
+  "Opens a raw WebSocket. `opts` may set :subprotocols, :headers, and :query-string."
+  [{:keys [subprotocols headers query-string]
     :or   {subprotocols ["graphql-ws"]}}]
   (let [messages-ch (chan 10)
+        url         (cond-> ws-url query-string (str "?" query-string))
         session     @(ws/websocket
-                       ws-url
+                       url
                        (cond-> {:subprotocols subprotocols
-                                :on-message   (fn [_ msg _last?]
-                                                (put! messages-ch
-                                                      (json/read-json (str msg) :key-fn keyword)))
-                                :on-error     (fn [_ error]
-                                                (log/error :reason ::ws-error :exception error))}
+                                :on-message (fn [_ msg _last?]
+                                              (put! messages-ch (json/read-json (str msg) :key-fn keyword)))
+                                :on-error   (fn [_ error]
+                                              (log/error :reason ::ws-error :exception error))}
                          headers (assoc :headers headers)))]
     {:session session :messages-ch messages-ch}))
 
 (defmacro with-connection
-  "Opens a connection with `opts`, binds tu/*session* and tu/*messages-ch* to it so the
-  test-utils helpers operate on it, and closes it afterwards."
+  "Opens a connection for `opts`, binds the test-utils session/channel vars to it, runs `body`,
+  then closes it."
   [opts & body]
   `(let [conn# (open-connection ~opts)]
      (binding [*session*        (:session conn#)
                tu/*messages-ch* (:messages-ch conn#)]
-       (try
-         ~@body
-         (finally
-           (ws/close! (:session conn#)))))))
+       (try ~@body
+            (finally (ws/close! (:session conn#)))))))
 
 (defn <non-ka!!
-  "Reads the next message, skipping over server keep-alive (:ka) messages."
+  "Next message, skipping keep-alives."
   ([] (<non-ka!! 250))
   ([timeout-ms]
    (loop []
      (let [message (<message!! timeout-ms)]
-       (if (= message {:type "ka"})
-         (recur)
-         message)))))
+       (if (= message {:type "ka"}) (recur) message)))))
 
-;; ---------------------------------------------------------------------------
-;; graphql-transport-ws protocol tests.
+(defn init!
+  "Sends connection_init (with optional payload) and asserts the ack."
+  ([] (init! nil))
+  ([payload]
+   (send-init payload)
+   (is (= {:type "connection_ack"} (<non-ka!!)))))
+
+(defn start!
+  "Starts an operation (op is :start or :subscribe) on a fresh id; returns the id."
+  [op query]
+  (let [id (swap! *subscriber-id inc)]
+    (send-data {:id id :type op :payload {:query query}})
+    id))
+
+(defn echo!
+  "Runs an echo query and drains both reply messages (data + complete), so the resolver has
+  captured its context and the channel is left clean for the next operation."
+  []
+  (start! :start "{ echo(value: \"ws\") { value }}")
+  (<non-ka!!)                            ; data
+  (<non-ka!!))                           ; complete
+
+;; --- graphql-transport-ws protocol ------------------------------------------
 
 (deftest transport-ws-ping-pong
-  ;; A graphql-transport-ws client may send "ping" at any time and must receive "pong".
   (with-connection {:subprotocols ["graphql-transport-ws"]}
-    (send-init)
-    (is (= {:type "connection_ack"} (<non-ka!!)))
-
+    (init!)
     (send-data {:type :ping})
     (is (= {:type "pong"} (<non-ka!!)))))
 
 (deftest transport-ws-subscribe-and-complete
-  ;; Over graphql-transport-ws, the client uses "subscribe"/"complete" and the server
-  ;; replies with "next" messages (not the legacy "data").
+  ;; "subscribe"/"complete" verbs, with "next" replies rather than the legacy "data".
   (with-connection {:subprotocols ["graphql-transport-ws"]}
-    (send-init)
-    (is (= {:type "connection_ack"} (<non-ka!!)))
+    (init!)
+    (let [id (start! :subscribe "subscription { ping(message: \"modern\", count: 2) { message }}")]
+      (is (= {:id id :type "next" :payload {:data {:ping {:message "modern #1"}}}} (<non-ka!!)))
+      (is (= {:id id :type "next" :payload {:data {:ping {:message "modern #2"}}}} (<non-ka!!)))
+      (is (= {:id id :type "complete"} (<non-ka!!))))))
 
-    (let [id (swap! *subscriber-id inc)]
-      (send-data {:id      id
-                  :type    :subscribe
-                  :payload {:query "subscription { ping(message: \"modern\", count: 2 ) { message }}"}})
-
-      (is (= {:id      id
-              :payload {:data {:ping {:message "modern #1"}}}
-              :type    "next"}
-             (<non-ka!!)))
-
-      (is (= {:id      id
-              :payload {:data {:ping {:message "modern #2"}}}
-              :type    "next"}
-             (<non-ka!!)))
-
-      (is (= {:id   id
-              :type "complete"}
-             (<non-ka!!))))))
-
-(deftest transport-ws-operation-uses-next
-  ;; A plain query over graphql-transport-ws is delivered as a "next" message followed by "complete".
+(deftest transport-ws-query-uses-next
+  ;; A plain query is delivered as "next" then "complete".
   (with-connection {:subprotocols ["graphql-transport-ws"]}
-    (send-init)
-    (is (= {:type "connection_ack"} (<non-ka!!)))
+    (init!)
+    (let [id (start! :subscribe "{ echo(value: \"modern\") { value }}")]
+      (is (= {:id id :type "next" :payload {:data {:echo {:value "modern"}}}} (<non-ka!!)))
+      (is (= {:id id :type "complete"} (<non-ka!!))))))
 
-    (let [id (swap! *subscriber-id inc)]
-      (send-data {:id      id
-                  :type    :subscribe
-                  :payload {:query "{ echo(value: \"modern\") { value }}"}})
+;; --- :context-initializer — who is the connected user? ----------------------
+;; The principal is established once at the handshake, from one of three channels, and must be
+;; visible to every resolver. The test resolvers capture their app-context into the
+;; *echo-context / *ping-context atoms.
 
-      (is (= {:id      id
-              :payload {:data {:echo {:value "modern"}}}
-              :type    "next"}
-             (<non-ka!!)))
-
-      (is (= {:id   id
-              :type "complete"}
-             (<non-ka!!))))))
-
-;; ---------------------------------------------------------------------------
-;; User-context tests.
-;;
-;; These exercise the intended use of :context-initializer (see the wiring above):
-;; the connection authenticates from the upgrade request, and the authenticated
-;; principal becomes visible to every resolver on the connection. The test resolvers
-;; (resolve-echo / stream-ping) capture their app-context into *echo-context /
-;; *ping-context, which is what we assert against.
-
-(deftest subscription-resolver-sees-authenticated-principal
-  ;; The principal established at connection open is visible to the subscription streamer.
+(deftest principal-from-authorization-header
   (with-connection {:headers {auth-header "token-alice"}}
-    (send-init)
-    (is (= {:type "connection_ack"} (<non-ka!!)))
+    (init!)
+    (echo!)
+    (is (= {:user "alice" :roles #{:admin}} (select-keys @*echo-context [:user :roles])))))
 
-    (let [id (swap! *subscriber-id inc)]
-      (send-data {:id      id
-                  :type    :start
-                  :payload {:query "subscription { ping(message: \"hi\", count: 1 ) { message }}"}})
-      (<non-ka!!)
-      (reporting {:context @*ping-context}
-        (is (= {:user "alice" :roles #{:admin}}
-               (select-keys @*ping-context [:user :roles]))
-            "The streamer's app-context carries the authenticated principal.")))))
+(deftest principal-from-url-token
+  ;; Browsers can't set headers, so they pass the token as ?access_token=… ; the
+  ;; :context-initializer reads it from the upgrade request's :query-string. (This also
+  ;; confirms pedestal3 surfaces the query-string on the upgrade.)
+  (with-connection {:query-string "access_token=token-alice"}
+    (init!)
+    (echo!)
+    (is (= {:user "alice" :roles #{:admin}} (select-keys @*echo-context [:user :roles])))))
 
-(deftest operation-resolver-sees-authenticated-principal
-  ;; The same principal is visible to plain query/mutation operations on the connection.
+(deftest principal-reaches-subscription-streamer
   (with-connection {:headers {auth-header "token-alice"}}
-    (send-init)
-    (is (= {:type "connection_ack"} (<non-ka!!)))
+    (init!)
+    (start! :start "subscription { ping(message: \"hi\", count: 1) { message }}")
+    (<non-ka!!)
+    (is (= {:user "alice" :roles #{:admin}} (select-keys @*ping-context [:user :roles])))))
 
-    (let [id (swap! *subscriber-id inc)]
-      (send-data {:id      id
-                  :type    :start
-                  :payload {:query "{ echo(value: \"ws\") { value }}"}})
-      (<non-ka!!)
-      (reporting {:context @*echo-context}
-        (is (= {:user "alice" :roles #{:admin}}
-               (select-keys @*echo-context [:user :roles]))
-            "The resolver's app-context carries the authenticated principal.")))))
-
-(deftest authenticated-principal-survives-multiple-operations
-  ;; The per-message app-context injection must not drop the connection principal; it must be
-  ;; present on every operation, not just the first.
+(deftest principal-survives-every-operation
+  ;; Per-message app-context injection must not drop the principal after the first operation.
   (with-connection {:headers {auth-header "token-bob"}}
-    (send-init)
-    (is (= {:type "connection_ack"} (<non-ka!!)))
-
+    (init!)
     (dotimes [_ 2]
       (reset! *echo-context nil)
-      (let [id (swap! *subscriber-id inc)]
-        (send-data {:id      id
-                    :type    :start
-                    :payload {:query "{ echo(value: \"ws\") { value }}"}})
-        (<non-ka!!)                                ; data/next
-        (<non-ka!!)                                ; complete
-        (is (= "bob" (:user @*echo-context)))))))
+      (echo!)
+      (is (= "bob" (:user @*echo-context))))))
 
 (deftest anonymous-connection-has-no-principal
-  ;; Without credentials, authenticate returns nil and nothing is merged into the app-context.
   (with-connection {}
-    (send-init)
-    (is (= {:type "connection_ack"} (<non-ka!!)))
+    (init!)
+    (echo!)
+    (is (nil? (:user @*echo-context)))))
 
-    (let [id (swap! *subscriber-id inc)]
-      (send-data {:id      id
-                  :type    :start
-                  :payload {:query "{ echo(value: \"ws\") { value }}"}})
-      (<non-ka!!)
-      (reporting {:context @*echo-context}
-        (is (nil? (:user @*echo-context)))
-        (is (nil? (:roles @*echo-context)))))))
+;; --- connection_init payload (::lacinia/connection-params) ------------------
+;; The other in-band channel — and, besides the URL, the only one a browser has: a
+;; client-supplied connection_init payload, surfaced to resolvers as ::lacinia/connection-params.
+;; It must keep working through this server's custom interceptor, independent of the principal.
+
+(deftest connection-init-params-reach-resolver
+  (with-connection {}
+    (init! {:authToken "abc"})
+    (echo!)
+    (is (= {:authToken "abc"} (::lacinia/connection-params @*echo-context)))))
+
+(deftest principal-from-connection-init-token
+  ;; The browser auth flow end-to-end: the token rides in the connection_init payload (not a
+  ;; header or the URL), is authenticated per operation — not by :context-initializer, which
+  ;; runs before the payload exists — and the resulting principal reaches the resolver.
+  (with-connection {}
+    (init! {:authToken "token-alice"})
+    (echo!)
+    (is (= {:user "alice" :roles #{:admin}} (select-keys @*echo-context [:user :roles])))))
+
+(deftest principal-and-connection-init-params-coexist
+  (with-connection {:headers {auth-header "token-alice"}}
+    (init! {:locale "en"})
+    (echo!)
+    (is (= "alice" (:user @*echo-context)))
+    (is (= {:locale "en"} (::lacinia/connection-params @*echo-context)))))

--- a/test/com/walmartlabs/lacinia/pedestal/graphql_ws_test.clj
+++ b/test/com/walmartlabs/lacinia/pedestal/graphql_ws_test.clj
@@ -1,0 +1,288 @@
+; Copyright (c) 2025-present Walmart, Inc.
+;
+; Licensed under the Apache License, Version 2.0 (the "License")
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+(ns com.walmartlabs.lacinia.pedestal.graphql-ws-test
+  "Tests for graphql-transport-ws protocol support and the :context-initializer hook in
+  subscriptions2 (the pedestal3 connector path).
+
+  Kept in its own namespace so the upstream pedestal3-test fixture and tests stay untouched:
+  this namespace stands up its own subscription server (on a separate port) wired with a
+  :context-initializer, and opens raw WebSocket connections so it can control the negotiated
+  subprotocol and the upgrade-request headers."
+  (:require [clojure.test :refer [deftest is use-fixtures]]
+            [com.walmartlabs.lacinia.pedestal.subscriptions2 :as subscriptions2]
+            [com.walmartlabs.lacinia.test-utils :as tu
+             :refer [*ping-context *echo-context *session*
+                     send-data send-init <message!! *subscriber-id]]
+            [io.pedestal.interceptor :refer [interceptor]]
+            [io.pedestal.http.route.definition.table :as table]
+            [io.pedestal.http.jetty :as jetty]
+            [charred.api :as json]
+            [hato.websocket :as ws]
+            [clojure.core.async :refer [chan put!]]
+            [io.pedestal.log :as log]
+            [com.walmartlabs.test-reporting :refer [reporting]]
+            [io.pedestal.connector :as conn]))
+
+;; Own port, so this server coexists with the upstream pedestal3-test server (8888).
+(def port 8889)
+
+(def ws-url (str "ws://localhost:" port "/ws"))
+
+;; ---------------------------------------------------------------------------
+;; User-context wiring for the subscription endpoint.
+;;
+;; This demonstrates the intended use of :context-initializer: authenticate the
+;; WebSocket upgrade once, stash the resulting principal on the per-connection
+;; context, and -- via a small user-land interceptor -- make it visible to every
+;; query and subscription resolver on that connection. The library stays free of
+;; any "user context" opinion; the bridge lives entirely in application code.
+
+(def ^:private auth-header "authorization")
+
+(defn ^:private authenticate
+  "Stand-in authentication: resolves the upgrade request to a principal map, or nil when the
+  request carries no recognized credentials (an anonymous connection)."
+  [request]
+  (case (get-in request [:headers auth-header])
+    "token-alice" {:user "alice" :roles #{:admin}}
+    "token-bob"   {:user "bob"   :roles #{:viewer}}
+    nil))
+
+(def ^:private principal-key ::principal)
+
+(defn ^:private inject-app-context+principal-interceptor
+  "Like the library's app-context injector, but also merges the connection-scoped principal
+  (placed on the context by the :context-initializer) into the resolver app-context. This is
+  the user-land bridge that carries the authenticated user into every resolver. A nil principal
+  (anonymous connection) merges to nothing."
+  [app-context]
+  (interceptor
+    {:name  ::inject-app-context+principal
+     :enter (fn [context]
+              (assoc-in context [:request :lacinia-app-context]
+                        (-> (or app-context {})
+                            (assoc :request (:request context))
+                            (merge (get context principal-key)))))}))
+
+(defn ^:private user-context-subscription-interceptor
+  "Builds the subscription interceptor used by the test server: a :context-initializer that
+  authenticates the upgrade request, plus a custom interceptor chain (identical to the library
+  default except that it swaps in [[inject-app-context+principal-interceptor]])."
+  [schema]
+  (subscriptions2/subscription-interceptor
+    schema
+    {:keep-alive-ms       200
+     :context-initializer (fn [context request]
+                            (assoc context principal-key (authenticate request)))
+     :subscription-interceptors
+     [subscriptions2/exception-handler-interceptor
+      subscriptions2/send-operation-response-interceptor
+      (subscriptions2/query-parser-interceptor schema)
+      (inject-app-context+principal-interceptor nil)
+      subscriptions2/execute-operation-interceptor]}))
+
+(defn server-fixture
+  [f]
+  (let [schema              (tu/compile-schema)
+        subscription-routes (table/table-routes
+                              [["/ws" :get (user-context-subscription-interceptor schema)
+                                :route-name ::subscriptions]])
+        connector           (-> (conn/default-connector-map port)
+                                (conn/with-routes subscription-routes)
+                                (jetty/create-connector nil)
+                                (conn/start!))]
+    (try
+      (f)
+      (finally
+        (conn/stop! connector)))))
+
+(use-fixtures :once server-fixture)
+
+;; ---------------------------------------------------------------------------
+;; Raw WebSocket helpers.
+;;
+;; These open their own connections so the tests can control the negotiated subprotocol
+;; and the upgrade-request headers, then rebind the test-utils dynamic vars so the existing
+;; send-*/<message!! helpers can be reused.
+
+(defn open-connection
+  "Opens a raw WebSocket connection to the subscription endpoint and returns a map of
+  {:session, :messages-ch}. `opts` may include :subprotocols and :headers."
+  [{:keys [subprotocols headers]
+    :or   {subprotocols ["graphql-ws"]}}]
+  (let [messages-ch (chan 10)
+        session     @(ws/websocket
+                       ws-url
+                       (cond-> {:subprotocols subprotocols
+                                :on-message   (fn [_ msg _last?]
+                                                (put! messages-ch
+                                                      (json/read-json (str msg) :key-fn keyword)))
+                                :on-error     (fn [_ error]
+                                                (log/error :reason ::ws-error :exception error))}
+                         headers (assoc :headers headers)))]
+    {:session session :messages-ch messages-ch}))
+
+(defmacro with-connection
+  "Opens a connection with `opts`, binds tu/*session* and tu/*messages-ch* to it so the
+  test-utils helpers operate on it, and closes it afterwards."
+  [opts & body]
+  `(let [conn# (open-connection ~opts)]
+     (binding [*session*        (:session conn#)
+               tu/*messages-ch* (:messages-ch conn#)]
+       (try
+         ~@body
+         (finally
+           (ws/close! (:session conn#)))))))
+
+(defn <non-ka!!
+  "Reads the next message, skipping over server keep-alive (:ka) messages."
+  ([] (<non-ka!! 250))
+  ([timeout-ms]
+   (loop []
+     (let [message (<message!! timeout-ms)]
+       (if (= message {:type "ka"})
+         (recur)
+         message)))))
+
+;; ---------------------------------------------------------------------------
+;; graphql-transport-ws protocol tests.
+
+(deftest transport-ws-ping-pong
+  ;; A graphql-transport-ws client may send "ping" at any time and must receive "pong".
+  (with-connection {:subprotocols ["graphql-transport-ws"]}
+    (send-init)
+    (is (= {:type "connection_ack"} (<non-ka!!)))
+
+    (send-data {:type :ping})
+    (is (= {:type "pong"} (<non-ka!!)))))
+
+(deftest transport-ws-subscribe-and-complete
+  ;; Over graphql-transport-ws, the client uses "subscribe"/"complete" and the server
+  ;; replies with "next" messages (not the legacy "data").
+  (with-connection {:subprotocols ["graphql-transport-ws"]}
+    (send-init)
+    (is (= {:type "connection_ack"} (<non-ka!!)))
+
+    (let [id (swap! *subscriber-id inc)]
+      (send-data {:id      id
+                  :type    :subscribe
+                  :payload {:query "subscription { ping(message: \"modern\", count: 2 ) { message }}"}})
+
+      (is (= {:id      id
+              :payload {:data {:ping {:message "modern #1"}}}
+              :type    "next"}
+             (<non-ka!!)))
+
+      (is (= {:id      id
+              :payload {:data {:ping {:message "modern #2"}}}
+              :type    "next"}
+             (<non-ka!!)))
+
+      (is (= {:id   id
+              :type "complete"}
+             (<non-ka!!))))))
+
+(deftest transport-ws-operation-uses-next
+  ;; A plain query over graphql-transport-ws is delivered as a "next" message followed by "complete".
+  (with-connection {:subprotocols ["graphql-transport-ws"]}
+    (send-init)
+    (is (= {:type "connection_ack"} (<non-ka!!)))
+
+    (let [id (swap! *subscriber-id inc)]
+      (send-data {:id      id
+                  :type    :subscribe
+                  :payload {:query "{ echo(value: \"modern\") { value }}"}})
+
+      (is (= {:id      id
+              :payload {:data {:echo {:value "modern"}}}
+              :type    "next"}
+             (<non-ka!!)))
+
+      (is (= {:id   id
+              :type "complete"}
+             (<non-ka!!))))))
+
+;; ---------------------------------------------------------------------------
+;; User-context tests.
+;;
+;; These exercise the intended use of :context-initializer (see the wiring above):
+;; the connection authenticates from the upgrade request, and the authenticated
+;; principal becomes visible to every resolver on the connection. The test resolvers
+;; (resolve-echo / stream-ping) capture their app-context into *echo-context /
+;; *ping-context, which is what we assert against.
+
+(deftest subscription-resolver-sees-authenticated-principal
+  ;; The principal established at connection open is visible to the subscription streamer.
+  (with-connection {:headers {auth-header "token-alice"}}
+    (send-init)
+    (is (= {:type "connection_ack"} (<non-ka!!)))
+
+    (let [id (swap! *subscriber-id inc)]
+      (send-data {:id      id
+                  :type    :start
+                  :payload {:query "subscription { ping(message: \"hi\", count: 1 ) { message }}"}})
+      (<non-ka!!)
+      (reporting {:context @*ping-context}
+        (is (= {:user "alice" :roles #{:admin}}
+               (select-keys @*ping-context [:user :roles]))
+            "The streamer's app-context carries the authenticated principal.")))))
+
+(deftest operation-resolver-sees-authenticated-principal
+  ;; The same principal is visible to plain query/mutation operations on the connection.
+  (with-connection {:headers {auth-header "token-alice"}}
+    (send-init)
+    (is (= {:type "connection_ack"} (<non-ka!!)))
+
+    (let [id (swap! *subscriber-id inc)]
+      (send-data {:id      id
+                  :type    :start
+                  :payload {:query "{ echo(value: \"ws\") { value }}"}})
+      (<non-ka!!)
+      (reporting {:context @*echo-context}
+        (is (= {:user "alice" :roles #{:admin}}
+               (select-keys @*echo-context [:user :roles]))
+            "The resolver's app-context carries the authenticated principal.")))))
+
+(deftest authenticated-principal-survives-multiple-operations
+  ;; The per-message app-context injection must not drop the connection principal; it must be
+  ;; present on every operation, not just the first.
+  (with-connection {:headers {auth-header "token-bob"}}
+    (send-init)
+    (is (= {:type "connection_ack"} (<non-ka!!)))
+
+    (dotimes [_ 2]
+      (reset! *echo-context nil)
+      (let [id (swap! *subscriber-id inc)]
+        (send-data {:id      id
+                    :type    :start
+                    :payload {:query "{ echo(value: \"ws\") { value }}"}})
+        (<non-ka!!)                                ; data/next
+        (<non-ka!!)                                ; complete
+        (is (= "bob" (:user @*echo-context)))))))
+
+(deftest anonymous-connection-has-no-principal
+  ;; Without credentials, authenticate returns nil and nothing is merged into the app-context.
+  (with-connection {}
+    (send-init)
+    (is (= {:type "connection_ack"} (<non-ka!!)))
+
+    (let [id (swap! *subscriber-id inc)]
+      (send-data {:id      id
+                  :type    :start
+                  :payload {:query "{ echo(value: \"ws\") { value }}"}})
+      (<non-ka!!)
+      (reporting {:context @*echo-context}
+        (is (nil? (:user @*echo-context)))
+        (is (nil? (:roles @*echo-context)))))))


### PR DESCRIPTION
Hi,

This pull request addresses 2 changes.

First one is support for **graphql-ws** protocol specification: https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md that is supported in newer versions of GraphiQL

Second one is **base-context initialisation for connection-loop**. Currently in subscriptions namespace there is no other way to extend base-context and include some ws request params data into base-context that connection-loop will use to process incoming GraphQL subscription request.

Why? Authorization i.e. If access_token is sent during ws establishment and user info (roles, groups) are important for subscription execution, base-context feels like logical place to hold that information. Since it is available to all subscription resolvers. Right? 

If I misunderstood current codebase i apologise and would be really grateful if u could show me workarounds.

Thanks,
Robert