### PR TITLE
fix: graphql-ws keep-alive fix for PR #147

### DIFF
--- a/src/com/walmartlabs/lacinia/pedestal/internal.clj
+++ b/src/com/walmartlabs/lacinia/pedestal/internal.clj
@@ -413,7 +413,12 @@
         (async/timeout keep-alive-ms)
         (do
           (log/trace :event ::timeout :session-id session-id)
-          (>! response-data-ch {:type :ka})
+          ;; Subprotocol-aware keep-alive: graphql-transport-ws has no "ka" message (an
+          ;; unknown type closes the connection on clients like Apollo/GraphiQL); its heartbeat
+          ;; is a "ping" (the client replies "pong"). Legacy graphql-ws uses "ka".
+          (>! response-data-ch (if (= "graphql-transport-ws" (::subprotocol context))
+                                 {:type :ping}
+                                 {:type :ka}))
           (recur connection-state))
 
         ws-data-ch
@@ -436,6 +441,11 @@
                "ping"
                (when (>! response-data-ch {:type :pong})
                  (recur connection-state))
+
+               ;; The client's reply to our keep-alive "ping" (or an unsolicited heartbeat).
+               ;; A "pong" requires no response; just keep listening.
+               "pong"
+               (recur connection-state)
 
                ;; TODO: Track state, don't allow start, etc. until after connection_init
 

--- a/test/com/walmartlabs/lacinia/pedestal/graphql_ws_test.clj
+++ b/test/com/walmartlabs/lacinia/pedestal/graphql_ws_test.clj
@@ -140,12 +140,12 @@
             (finally (ws/close! (:session conn#)))))))
 
 (defn <non-ka!!
-  "Next message, skipping keep-alives."
+  "Next message, skipping server keep-alives: legacy \"ka\" and graphql-transport-ws \"ping\"."
   ([] (<non-ka!! 250))
   ([timeout-ms]
    (loop []
      (let [message (<message!! timeout-ms)]
-       (if (= message {:type "ka"}) (recur) message)))))
+       (if (#{"ka" "ping"} (:type message)) (recur) message)))))
 
 (defn init!
   "Sends connection_init (with optional payload) and asserts the ack."
@@ -193,6 +193,22 @@
     (let [id (start! :subscribe "{ echo(value: \"modern\") { value }}")]
       (is (= {:id id :type "next" :payload {:data {:echo {:value "modern"}}}} (<non-ka!!)))
       (is (= {:id id :type "complete"} (<non-ka!!))))))
+
+(deftest transport-ws-keepalive-is-ping-not-ka
+  ;; graphql-transport-ws has no "ka" (an unknown type closes real clients like Apollo/GraphiQL);
+  ;; the idle heartbeat must be a "ping". Read raw (<message!!) so the keep-alive is NOT skipped.
+  (with-connection {:subprotocols ["graphql-transport-ws"]}
+    (init!)
+    (is (= {:type "ping"} (<message!! 1000)))))
+
+(deftest server-tolerates-client-pong
+  ;; The client's pong (its reply to our ping, or an unsolicited heartbeat) must not error the
+  ;; connection -- it stays healthy and further operations still work.
+  (with-connection {:subprotocols ["graphql-transport-ws"]}
+    (init!)
+    (send-data {:type :pong})
+    (let [id (start! :subscribe "{ echo(value: \"ok\") { value }}")]
+      (is (= {:id id :type "next" :payload {:data {:echo {:value "ok"}}}} (<non-ka!!))))))
 
 ;; --- :context-initializer — who is the connected user? ----------------------
 ;; The principal is established once at the handshake, from one of three channels, and must be


### PR DESCRIPTION
Hi Howard,

Thanks for merging #147! Small follow-up I caught while validating against real clients.

Problem: the subscription keep-alive sends a ka message on every connection. `ka` is a legacy subscriptions-transport-ws message — it isn't part of graphql-transport-ws, so a modern client (Apollo / GraphiQL via graphql-ws) treats it as invalid and closes the socket (4004) after the first
idle keep-alive:

NEXT {"data":{"ticks":1}}
SOCKET-ERROR Invalid message 'type' property "ka"
CLOSED code=4004

Fix: make the keep-alive subprotocol-aware — `ping` for graphql-transport-ws (the client replies `pong`, which the server now also accepts), `ka` for 
legacy graphql-ws. Matches the spec (`ping/pong` is the transport-ws heartbeat; there's no `ka`), legacy path unchanged.

Tested e2e with both real clients — graphql-ws and subscriptions-transport-ws — plus regression tests. Full suite green.

**Closes #123**